### PR TITLE
Button component

### DIFF
--- a/packages/@logossim/components/Button/ButtonIcon.jsx
+++ b/packages/@logossim/components/Button/ButtonIcon.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Shape } from './ButtonWidget';
+
+const ButtonIcon = () => <Shape size={30} />;
+
+export default ButtonIcon;

--- a/packages/@logossim/components/Button/ButtonModel.js
+++ b/packages/@logossim/components/Button/ButtonModel.js
@@ -1,0 +1,27 @@
+import { BaseModel } from '@logossim/core';
+
+export default class ButtonModel extends BaseModel {
+  initialize() {
+    this.addPort('out');
+  }
+
+  onSimulationStart() {
+    console.log('ButtonModel onSimulationStart');
+  }
+
+  onSimulationEnd() {
+    console.log('ButtonModel onSimulationEnd');
+  }
+
+  step(inputs) {
+    console.log('ButtonModel step', inputs);
+  }
+
+  onClick() {
+    console.log('ButtonModel onClick');
+  }
+
+  onRelease() {
+    console.log('ButtonModel onRelease');
+  }
+}

--- a/packages/@logossim/components/Button/ButtonRegister.js
+++ b/packages/@logossim/components/Button/ButtonRegister.js
@@ -1,0 +1,15 @@
+import { Component } from '@logossim/core';
+import widget from './ButtonWidget';
+import model from './ButtonModel';
+import icon from './ButtonIcon';
+
+export default new Component({
+  type: 'Button',
+  name: 'Button',
+  description: 'Simple button',
+  group: 'Input & output',
+  configurations: [],
+  model,
+  widget,
+  icon,
+});

--- a/packages/@logossim/components/Button/ButtonWidget.jsx
+++ b/packages/@logossim/components/Button/ButtonWidget.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Port } from '@logossim/core';
+
+const Wrapper = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 30px;
+  height: 30px;
+
+  transition: 100ms linear;
+  svg {
+    fill: ${props =>
+      props.selected
+        ? 'var(--body-selected)'
+        : 'var(--body-unselected)'};
+    stroke: ${props =>
+      props.selected
+        ? 'var(--border-selected)'
+        : 'var(--border-unselected)'};
+  }
+`;
+
+const Button = styled.button`
+  position: absolute;
+  border-radius: 50%;
+  width: 18px;
+  height: 18px;
+  outline: none;
+
+  border: 2px solid rgba(0, 0, 0, 0.3);
+  background: linear-gradient(
+    225deg,
+    rgba(238, 0, 0, 1) 0%,
+    rgba(125, 20, 20, 1) 100%
+  );
+
+  :active {
+    border: 2px solid rgba(255, 255, 255, 0.5);
+    background: linear-gradient(
+      225deg,
+      rgba(125, 20, 20, 1) 0%,
+      rgba(238, 0, 0, 1) 100%
+    );
+  }
+`;
+
+const PositionedPort = styled(Port)`
+  position: absolute;
+  right: -5px;
+`;
+
+export const Shape = ({ size = 30 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 7.9374997 7.9375003"
+    fill="var(--body-unselected)"
+    stroke="var(--border-unselected)"
+    strokeWidth="1"
+  >
+    <g>
+      <rect
+        y="0.26458332"
+        x="0.26458332"
+        height="7.4083333"
+        width="7.4083333"
+      />
+    </g>
+  </svg>
+);
+
+const ButtonWidget = props => {
+  const { model, node, engine } = props;
+  const {
+    options: { selected },
+  } = node;
+
+  return (
+    <Wrapper selected={selected}>
+      <PositionedPort
+        name="out"
+        node={node}
+        port={node.getPort('out')}
+        engine={engine}
+      />
+      <Shape />
+      <Button
+        onMouseDown={() => model.onClick()}
+        onMouseUp={() => model.onRelease()}
+      />
+    </Wrapper>
+  );
+};
+
+export default ButtonWidget;

--- a/packages/@logossim/components/index.js
+++ b/packages/@logossim/components/index.js
@@ -1,4 +1,5 @@
 import And from './And/AndRegister';
 import Or from './Or/OrRegister';
+import Button from './Button/ButtonRegister';
 
-export default [And, Or];
+export default [And, Or, Button];

--- a/packages/@logossim/core/Component.jsx
+++ b/packages/@logossim/core/Component.jsx
@@ -24,12 +24,25 @@ export default class Component extends AbstractReactFactory {
 
   generateReactWidget(event) {
     const { Widget } = this;
-    return <Widget engine={this.engine} node={event.model} />;
+
+    return (
+      <Widget
+        engine={this.engine}
+        node={event.model}
+        model={this.generateModel({
+          initialConfig: {
+            ...event.model.options,
+            configurations: event.model.configurations,
+          },
+        })}
+      />
+    );
   }
 
   generateModel(event) {
     const { Model } = this;
     const { type, configurations } = event.initialConfig;
+
     return new Model(type, configurations);
   }
 }

--- a/packages/@logossim/core/Diagram/states/MoveItemsState.js
+++ b/packages/@logossim/core/Diagram/states/MoveItemsState.js
@@ -31,6 +31,8 @@ export default class MoveItemsState extends AbstractDisplacementState {
       new Action({
         type: InputType.MOUSE_DOWN,
         fire: event => {
+          if (this.engine.getModel().isLocked()) return;
+
           this.lastDisplacement = new Point(0, 0);
 
           const element = this.engine

--- a/packages/@logossim/core/Diagram/states/SelectionBoxState.js
+++ b/packages/@logossim/core/Diagram/states/SelectionBoxState.js
@@ -71,26 +71,26 @@ export default class SelectionBoxState extends AbstractDisplacementState {
       Math.abs(event.virtualDisplacementY),
     );
 
-    this.engine
-      .getModel()
-      .getSelectionEntities()
-      .forEach(model => {
-        if (model.getBoundingBox) {
-          if (!this.allowSelection(model)) {
-            return;
-          }
+    if (!this.engine.getModel().isLocked()) {
+      this.engine
+        .getModel()
+        .getSelectionEntities()
+        .forEach(model => {
+          if (model.getBoundingBox) {
+            if (!this.allowSelection(model)) return;
 
-          const bounds = model.getBoundingBox();
-          if (
-            rect.containsPoint(bounds.getTopLeft()) &&
-            rect.containsPoint(bounds.getBottomRight())
-          ) {
-            model.setSelected(true);
-          } else {
-            model.setSelected(false);
+            const bounds = model.getBoundingBox();
+            if (
+              rect.containsPoint(bounds.getTopLeft()) &&
+              rect.containsPoint(bounds.getBottomRight())
+            ) {
+              model.setSelected(true);
+            } else {
+              model.setSelected(false);
+            }
           }
-        }
-      });
+        });
+    }
 
     this.engine.repaintCanvas();
   }

--- a/packages/@logossim/page/src/ui-components/ComponentSelect/DraggableComponent.jsx
+++ b/packages/@logossim/page/src/ui-components/ComponentSelect/DraggableComponent.jsx
@@ -4,6 +4,7 @@ const engineStub = {
   registerListener: () => {},
   getCanvas: () => {},
   getPortCoords: () => {},
+  getModel: () => ({ isLocked: () => false }),
 };
 
 const nodeStub = {
@@ -11,6 +12,19 @@ const nodeStub = {
   getID: () => {},
   options: { selected: false },
 };
+
+/**
+ * Proxy is used here to return a function for whatever object key is
+ * asked for.
+ */
+const modelStub = new Proxy(
+  {},
+  {
+    get: () => {
+      return () => {};
+    },
+  },
+);
 
 const DraggableComponent = ({
   component: { type, Widget },
@@ -34,12 +48,13 @@ const DraggableComponent = ({
         }),
       );
 
-      setTimeout(handleClose);
+      requestAnimationFrame(handleClose);
     }}
   >
     <Widget
       engine={engineStub}
       node={{ ...nodeStub, configurations }}
+      model={modelStub}
     />
   </div>
 );

--- a/packages/@logossim/page/src/ui-components/ComponentSelect/DraggableComponent.jsx
+++ b/packages/@logossim/page/src/ui-components/ComponentSelect/DraggableComponent.jsx
@@ -20,9 +20,7 @@ const nodeStub = {
 const modelStub = new Proxy(
   {},
   {
-    get: () => {
-      return () => {};
-    },
+    get: () => () => {},
   },
 );
 


### PR DESCRIPTION
Adjustments in order to pass `model` props to `Widget`s. This will be useful to centralize all handlers on the `Model` itself, and only call it when needed on the `Widget`. On the `DraggableComponent`, in order to generate a dynamic stub for the `model` prop, I ended up using the `Proxy` class.

Adds initial implementation for the button component.

![image](https://user-images.githubusercontent.com/25781956/75627406-94f8ec80-5bae-11ea-8871-2d4e8d97782a.png)
