### PR TITLE
Values as array, floating values, new components and improvements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,7 @@
   "rules": {
     "prettier/prettier": ["error"],
     "no-bitwise": "off",
+    "consistent-return": "off",
     "react/prop-types": "off",
     "react/sort-comp": "off",
     "react/jsx-props-no-spreading": "off",
@@ -54,5 +55,13 @@
   "env": {
     "browser": true,
     "jest": true
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.test.js"],
+      "rules": {
+        "no-new": "off"
+      }
+    }
+  ]
 }

--- a/packages/@logossim/component-creator/templates/Audio/AudioModel.hbs
+++ b/packages/@logossim/component-creator/templates/Audio/AudioModel.hbs
@@ -10,6 +10,8 @@ export default class {{fileName name}}Model extends BaseModel {
 
   onSimulationStart() {
     this.audio = this.createAudio(this.frequencyHz, this.waveform);
+
+    if (this.getInput() === 1) this.audio.play();
   }
 
   onSimulationPause() {
@@ -24,10 +26,14 @@ export default class {{fileName name}}Model extends BaseModel {
     }
   }
 
-  isActive() {
-    const input = this.getPort('in').getValue() || 0;
+  getInput() {
+    const value = this.getPort('in').getValue();
 
-    if (input === 0) return false;
-    return true;
+    if (!value) return 0;
+    return value[0];
+  }
+
+  isActive() {
+    return !!this.getInput()[0];
   }
 }

--- a/packages/@logossim/component-creator/templates/Audio/AudioWidget.hbs
+++ b/packages/@logossim/component-creator/templates/Audio/AudioWidget.hbs
@@ -48,7 +48,7 @@ export const Shape = ({ selected, isActive, children }) => (
 );
 
 export const {{fileName name}}Widget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
   } = model;
@@ -58,7 +58,6 @@ export const {{fileName name}}Widget = props => {
       <PositionedPort
         name="in"
         model={model}
-        engine={engine}
       />
     </Shape>
   );

--- a/packages/@logossim/component-creator/templates/Audio/AudioWidget.hbs
+++ b/packages/@logossim/component-creator/templates/Audio/AudioWidget.hbs
@@ -58,7 +58,6 @@ export const {{fileName name}}Widget = props => {
       <PositionedPort
         name="in"
         model={model}
-        port={model.getPort('in')}
         engine={engine}
       />
     </Shape>

--- a/packages/@logossim/component-creator/templates/Audio/AudioWidget.hbs
+++ b/packages/@logossim/component-creator/templates/Audio/AudioWidget.hbs
@@ -55,10 +55,7 @@ export const {{fileName name}}Widget = props => {
 
   return (
     <Shape selected={selected} isActive={model.isActive()}>
-      <PositionedPort
-        name="in"
-        model={model}
-      />
+      <PositionedPort name="in" />
     </Shape>
   );
 };

--- a/packages/@logossim/component-creator/templates/Audio/__tests__/AudioModel.test.hbs
+++ b/packages/@logossim/component-creator/templates/Audio/__tests__/AudioModel.test.hbs
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import {{fileName name}}Model from '../{{fileName name}}Model';
 
 const { addPort } = global;

--- a/packages/@logossim/component-creator/templates/Audio/__tests__/AudioModel.test.hbs
+++ b/packages/@logossim/component-creator/templates/Audio/__tests__/AudioModel.test.hbs
@@ -2,56 +2,65 @@ import {{fileName name}}Model from '../{{fileName name}}Model';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const spy = jest.spyOn({{fileName name}}Model.prototype, 'addInputPort');
-  spy.mockImplementation(addPort);
-
-  new {{fileName name}}Model();
-
-  expect(spy).toHaveBeenCalledWith('in');
-});
-
-it('should instantiate audio on simulation start with correct parameters', () => {
-  const model = new {{fileName name}}Model({
-    FREQUENCY_HZ: 1000,
-    WAVEFORM: 'SAWTOOTH',
+describe('{{fileName name}}Model', () => {
+  beforeEach(() => {
+    const getPortSpy = jest.spyOn({{fileName name}}Model.prototype, 'getPort');
+    getPortSpy.mockImplementation(() => ({
+      getValue: () => [0],
+    }));
   });
-  const spy = jest.spyOn(model, 'createAudio');
 
-  model.onSimulationStart();
+  it('should add ports on initialization', () => {
+    const spy = jest.spyOn({{fileName name}}Model.prototype, 'addInputPort');
+    spy.mockImplementation(addPort);
 
-  expect(spy).toHaveBeenCalledWith(1000, 'SAWTOOTH');
-});
+    new {{fileName name}}Model();
 
-it('should pause the audio on simulation pause', () => {
-  const model = new {{fileName name}}Model();
-  model.audio = { pause: () => {} };
+    expect(spy).toHaveBeenCalledWith('in');
+  });
 
-  const spy = jest.spyOn(model.audio, 'pause');
+  it('should instantiate audio on simulation start with correct parameters', () => {
+    const model = new {{fileName name}}Model({
+      FREQUENCY_HZ: 1000,
+      WAVEFORM: 'SAWTOOTH',
+    });
+    const spy = jest.spyOn(model, 'createAudio');
 
-  model.onSimulationPause();
+    model.onSimulationStart();
 
-  expect(spy).toHaveBeenCalled();
-});
+    expect(spy).toHaveBeenCalledWith(1000, 'SAWTOOTH');
+  });
 
-it('should play the audio when input is high', () => {
-  const model = new {{fileName name}}Model();
-  model.audio = { play: () => {} };
+  it('should pause the audio on simulation pause', () => {
+    const model = new {{fileName name}}Model();
+    model.audio = { pause: () => {} };
 
-  const spy = jest.spyOn(model.audio, 'play');
+    const spy = jest.spyOn(model.audio, 'pause');
 
-  model.step({ in: 1 });
+    model.onSimulationPause();
 
-  expect(spy).toHaveBeenCalled();
-});
+    expect(spy).toHaveBeenCalled();
+  });
 
-it('should pause the audio when input is low', () => {
-  const model = new {{fileName name}}Model();
-  model.audio = { pause: () => {} };
+  it('should play the audio when input is high', () => {
+    const model = new {{fileName name}}Model();
+    model.audio = { play: () => {} };
 
-  const spy = jest.spyOn(model.audio, 'pause');
+    const spy = jest.spyOn(model.audio, 'play');
 
-  model.step({ in: 0 });
+    model.step({ in: 1 });
 
-  expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should pause the audio when input is low', () => {
+    const model = new {{fileName name}}Model();
+    model.audio = { pause: () => {} };
+
+    const spy = jest.spyOn(model.audio, 'pause');
+
+    model.step({ in: 0 });
+
+    expect(spy).toHaveBeenCalled();
+  });
 });

--- a/packages/@logossim/component-creator/templates/Audio/__tests__/AudioWidget.test.hbs
+++ b/packages/@logossim/component-creator/templates/Audio/__tests__/AudioWidget.test.hbs
@@ -1,43 +1,44 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import {{fileName name}}Model from '../{{fileName name}}Model';
-import {{fileName name}}Widget from '../{{fileName name}}Widget';
+import { {{fileName name}}Widget } from '../{{fileName name}}Widget';
 
-it('should have 1 input port', () => {
-  const model = new {{fileName name}}Model();
+describe('{{fileName name}}Widget', () => {
+  it('should have 1 input port', () => {
+    const model = new {{fileName name}}Model();
 
-  const { container } = render(
-    <{{fileName name}}Widget model={model} />,
-  );
+    const { container } = render(
+      <{{fileName name}}Widget model={model} />,
+    );
 
-  const ports = container.querySelectorAll('[data-name=in]');
-  expect(ports).toHaveLength(1);
-});
+    const ports = container.querySelectorAll('[data-name=in]');
+    expect(ports).toHaveLength(1);
+  });
 
-it('should display a shadow when active', () => {
-  const model = new {{fileName name}}Model();
-  const spy = jest.spyOn(model, 'isActive');
-  spy.mockImplementation(() => true);
+  it('should display a shadow when active', () => {
+    const model = new {{fileName name}}Model();
+    const spy = jest.spyOn(model, 'isActive');
+    spy.mockImplementation(() => true);
 
-  const { getByTestId } = render(
-    <{{fileName name}}Widget model={model} />,
-  );
-  const body = getByTestId('body');
+    const { getByTestId } = render(
+      <{{fileName name}}Widget model={model} />,
+    );
+    const body = getByTestId('body');
 
-  expect(body).toHaveStyle('box-shadow: 0 0 15px black');
-});
+    expect(body).toHaveStyle('box-shadow: 0 0 15px black');
+  });
 
-it('should not display a shadow when inactive', () => {
-  const model = new {{fileName name}}Model();
-  const spy = jest.spyOn(model, 'isActive');
-  spy.mockImplementation(() => false);
+  it('should not display a shadow when inactive', () => {
+    const model = new {{fileName name}}Model();
+    const spy = jest.spyOn(model, 'isActive');
+    spy.mockImplementation(() => false);
 
-  const { getByTestId } = render(
-    <{{fileName name}}Widget model={model} />,
-  );
-  const body = getByTestId('body');
+    const { getByTestId } = render(
+      <{{fileName name}}Widget model={model} />,
+    );
+    const body = getByTestId('body');
 
-  expect(body).toHaveStyle('box-shadow: 0 0 0px black');
+    expect(body).toHaveStyle('box-shadow: 0 0 0px black');
+  });
 });

--- a/packages/@logossim/component-creator/templates/Audio/__tests__/AudioWidget.test.hbs
+++ b/packages/@logossim/component-creator/templates/Audio/__tests__/AudioWidget.test.hbs
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render } from '../../testUtils';
+import { render } from '@testing-library/react';
 
 import {{fileName name}}Model from '../{{fileName name}}Model';
 import {{fileName name}}Widget from '../{{fileName name}}Widget';

--- a/packages/@logossim/component-creator/templates/Audio/__tests__/AudioWidget.test.hbs
+++ b/packages/@logossim/component-creator/templates/Audio/__tests__/AudioWidget.test.hbs
@@ -1,17 +1,15 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render } from '../../testUtils';
 
 import {{fileName name}}Model from '../{{fileName name}}Model';
 import {{fileName name}}Widget from '../{{fileName name}}Widget';
-
-const { engine } = global;
 
 it('should have 1 input port', () => {
   const model = new {{fileName name}}Model();
 
   const { container } = render(
-    <{{fileName name}}Widget model={model} engine={engine} />,
+    <{{fileName name}}Widget model={model} />,
   );
 
   const ports = container.querySelectorAll('[data-name=in]');
@@ -24,7 +22,7 @@ it('should display a shadow when active', () => {
   spy.mockImplementation(() => true);
 
   const { getByTestId } = render(
-    <{{fileName name}}Widget model={model} engine={engine} />,
+    <{{fileName name}}Widget model={model} />,
   );
   const body = getByTestId('body');
 
@@ -37,7 +35,7 @@ it('should not display a shadow when inactive', () => {
   spy.mockImplementation(() => false);
 
   const { getByTestId } = render(
-    <{{fileName name}}Widget model={model} engine={engine} />,
+    <{{fileName name}}Widget model={model} />,
   );
   const body = getByTestId('body');
 

--- a/packages/@logossim/component-creator/templates/Button/ButtonWidget.hbs
+++ b/packages/@logossim/component-creator/templates/Button/ButtonWidget.hbs
@@ -81,10 +81,7 @@ const {{fileName name}}Widget = props => {
 
   return (
     <Shape selected={selected}>
-      <PositionedPort
-        name="out"
-        model={model}
-      />
+      <PositionedPort name="out" />
       <Button
         ref={buttonRef}
         onMouseDown={() => model.onClick()}

--- a/packages/@logossim/component-creator/templates/Button/ButtonWidget.hbs
+++ b/packages/@logossim/component-creator/templates/Button/ButtonWidget.hbs
@@ -84,7 +84,6 @@ const {{fileName name}}Widget = props => {
       <PositionedPort
         name="out"
         model={model}
-        port={model.getPort('out')}
         engine={engine}
       />
       <Button

--- a/packages/@logossim/component-creator/templates/Button/ButtonWidget.hbs
+++ b/packages/@logossim/component-creator/templates/Button/ButtonWidget.hbs
@@ -57,7 +57,7 @@ const PositionedPort = styled(Port)`
 `;
 
 const {{fileName name}}Widget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
   } = model;
@@ -84,7 +84,6 @@ const {{fileName name}}Widget = props => {
       <PositionedPort
         name="out"
         model={model}
-        engine={engine}
       />
       <Button
         ref={buttonRef}

--- a/packages/@logossim/component-creator/templates/Button/__tests__/ButtonModel.test.hbs
+++ b/packages/@logossim/component-creator/templates/Button/__tests__/ButtonModel.test.hbs
@@ -2,37 +2,39 @@ import {{fileName name}}Model from '../{{fileName name}}Model';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const spy = jest.spyOn({{fileName name}}Model.prototype, 'addOutputPort');
-  spy.mockImplementation(addPort);
+describe('{{fileName name}}Model', () => {
+  it('should add ports on initialization', () => {
+    const spy = jest.spyOn({{fileName name}}Model.prototype, 'addOutputPort');
+    spy.mockImplementation(addPort);
 
-  new {{fileName name}}Model();
+    new {{fileName name}}Model();
 
-  expect(spy).toHaveBeenCalledWith('out');
-});
+    expect(spy).toHaveBeenCalledWith('out');
+  });
 
-it('should emit on simulation start', () => {
-  const model = new {{fileName name}}Model();
-  const spy = jest.spyOn(model, 'emit');
-  model.onSimulationStart();
+  it('should emit on simulation start', () => {
+    const model = new {{fileName name}}Model();
+    const spy = jest.spyOn(model, 'emit');
+    model.onSimulationStart();
 
-  expect(spy).toHaveBeenCalledWith({ out: 0 });
-});
+    expect(spy).toHaveBeenCalledWith({ out: 0 });
+  });
 
-it('should emit correctly on click', () => {
-  const model = new {{fileName name}}Model();
-  const emitSpy = jest.spyOn(model, 'emit');
+  it('should emit correctly on click', () => {
+    const model = new {{fileName name}}Model();
+    const emitSpy = jest.spyOn(model, 'emit');
 
-  model.onClick();
+    model.onClick();
 
-  expect(emitSpy).toHaveBeenCalledWith({ out: 1 });
-});
+    expect(emitSpy).toHaveBeenCalledWith({ out: 1 });
+  });
 
-it('should emit correctly on release', () => {
-  const model = new {{fileName name}}Model();
-  const emitSpy = jest.spyOn(model, 'emit');
+  it('should emit correctly on release', () => {
+    const model = new {{fileName name}}Model();
+    const emitSpy = jest.spyOn(model, 'emit');
 
-  model.onRelease();
+    model.onRelease();
 
-  expect(emitSpy).toHaveBeenCalledWith({ out: 0 });
+    expect(emitSpy).toHaveBeenCalledWith({ out: 0 });
+  });
 });

--- a/packages/@logossim/component-creator/templates/Button/__tests__/ButtonModel.test.hbs
+++ b/packages/@logossim/component-creator/templates/Button/__tests__/ButtonModel.test.hbs
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import {{fileName name}}Model from '../{{fileName name}}Model';
 
 const { addPort } = global;

--- a/packages/@logossim/component-creator/templates/Button/__tests__/ButtonWidget.test.hbs
+++ b/packages/@logossim/component-creator/templates/Button/__tests__/ButtonWidget.test.hbs
@@ -1,18 +1,16 @@
 import React from 'react';
 
 import { fireEvent } from '@testing-library/dom';
-import { render } from '@testing-library/react';
+import { render } from '../../testUtils';
 
 import {{fileName name}}Model from '../{{fileName name}}Model';
 import {{fileName name}}Widget from '../{{fileName name}}Widget';
-
-const { engine } = global;
 
 it('should have 1 output port', () => {
   const model = new {{fileName name}}Model();
 
   const { container } = render(
-    <{{fileName name}}Widget model={model} engine={engine} />,
+    <{{fileName name}}Widget model={model} />,
   );
 
   const ports = container.querySelectorAll('[data-name=out]');
@@ -24,7 +22,7 @@ it('should call model onClick on mouse down event', () => {
   const spy = jest.spyOn(model, 'onClick');
 
   const { getByRole } = render(
-    <{{fileName name}}Widget model={model} engine={engine} />,
+    <{{fileName name}}Widget model={model} />,
   );
   const button = getByRole('button');
 
@@ -37,7 +35,7 @@ it('should call model onRelease on mouse up event', () => {
   const model = new {{fileName name}}Model();
   const spy = jest.spyOn(model, 'onRelease');
 
-  render(<{{fileName name}}Widget model={model} engine={engine} />);
+  render(<{{fileName name}}Widget model={model} />);
 
   fireEvent.mouseUp(document.body);
 

--- a/packages/@logossim/component-creator/templates/Button/__tests__/ButtonWidget.test.hbs
+++ b/packages/@logossim/component-creator/templates/Button/__tests__/ButtonWidget.test.hbs
@@ -1,43 +1,45 @@
 import React from 'react';
 
 import { fireEvent } from '@testing-library/dom';
-import { render } from '../../testUtils';
 
+import { render } from '../../testUtils';
 import {{fileName name}}Model from '../{{fileName name}}Model';
 import {{fileName name}}Widget from '../{{fileName name}}Widget';
 
-it('should have 1 output port', () => {
-  const model = new {{fileName name}}Model();
+describe('{{fileName name}}Widget', () => {
+  it('should have 1 output port', () => {
+    const model = new {{fileName name}}Model();
 
-  const { container } = render(
-    <{{fileName name}}Widget model={model} />,
-  );
+    const { container } = render(
+      <{{fileName name}}Widget model={model} />,
+    );
 
-  const ports = container.querySelectorAll('[data-name=out]');
-  expect(ports).toHaveLength(1);
-});
+    const ports = container.querySelectorAll('[data-name=out]');
+    expect(ports).toHaveLength(1);
+  });
 
-it('should call model onClick on mouse down event', () => {
-  const model = new {{fileName name}}Model();
-  const spy = jest.spyOn(model, 'onClick');
+  it('should call model onClick on mouse down event', () => {
+    const model = new {{fileName name}}Model();
+    const spy = jest.spyOn(model, 'onClick');
 
-  const { getByRole } = render(
-    <{{fileName name}}Widget model={model} />,
-  );
-  const button = getByRole('button');
+    const { getByRole } = render(
+      <{{fileName name}}Widget model={model} />,
+    );
+    const button = getByRole('button');
 
-  fireEvent.mouseDown(button);
+    fireEvent.mouseDown(button);
 
-  expect(spy).toHaveBeenCalledTimes(1);
-});
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
 
-it('should call model onRelease on mouse up event', () => {
-  const model = new {{fileName name}}Model();
-  const spy = jest.spyOn(model, 'onRelease');
+  it('should call model onRelease on mouse up event', () => {
+    const model = new {{fileName name}}Model();
+    const spy = jest.spyOn(model, 'onRelease');
 
-  render(<{{fileName name}}Widget model={model} />);
+    render(<{{fileName name}}Widget model={model} />);
 
-  fireEvent.mouseUp(document.body);
+    fireEvent.mouseUp(document.body);
 
-  expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/@logossim/component-creator/templates/Gate/GateModel.hbs
+++ b/packages/@logossim/component-creator/templates/Gate/GateModel.hbs
@@ -4,8 +4,8 @@ export default class {{fileName name}}Model extends BaseModel {
   initialize(configurations) {
     const DATA_BITS = Number(configurations.DATA_BITS);
 
-    this.addInputPort('in', DATA_BITS);
-    this.addOutputPort('out', DATA_BITS);
+    this.addInputPort('in', { bits: DATA_BITS });
+    this.addOutputPort('out', { bits: DATA_BITS });
   }
 
   step(input) {

--- a/packages/@logossim/component-creator/templates/Gate/GateWidget.hbs
+++ b/packages/@logossim/component-creator/templates/Gate/GateWidget.hbs
@@ -59,14 +59,8 @@ const {{fileName name}}Widget = props => {
 
   return (
     <Wrapper selected={selected}>
-      <PositionedPort
-        name="in"
-        model={model}
-      />
-      <PositionedPort
-        name="out"
-        model={model}
-      />
+      <PositionedPort name="in" />
+      <PositionedPort name="out" />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/component-creator/templates/Gate/GateWidget.hbs
+++ b/packages/@logossim/component-creator/templates/Gate/GateWidget.hbs
@@ -52,7 +52,7 @@ export const Shape = ({ size = 30 }) => (
 );
 
 const {{fileName name}}Widget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
   } = model;
@@ -62,12 +62,10 @@ const {{fileName name}}Widget = props => {
       <PositionedPort
         name="in"
         model={model}
-        engine={engine}
       />
       <PositionedPort
         name="out"
         model={model}
-        engine={engine}
       />
       <Shape />
     </Wrapper>

--- a/packages/@logossim/component-creator/templates/Gate/GateWidget.hbs
+++ b/packages/@logossim/component-creator/templates/Gate/GateWidget.hbs
@@ -62,13 +62,11 @@ const {{fileName name}}Widget = props => {
       <PositionedPort
         name="in"
         model={model}
-        port={model.getPort('in')}
         engine={engine}
       />
       <PositionedPort
         name="out"
         model={model}
-        port={model.getPort('out')}
         engine={engine}
       />
       <Shape />

--- a/packages/@logossim/component-creator/templates/Gate/__tests__/GateModel.test.hbs
+++ b/packages/@logossim/component-creator/templates/Gate/__tests__/GateModel.test.hbs
@@ -5,18 +5,20 @@ import { render } from '../../testUtils';
 import {{fileName name}}Model from '../{{fileName name}}Model';
 import {{fileName name}}Widget from '../{{fileName name}}Widget';
 
-it('should have 1 input and 1 output port', () => {
-  const model = new {{fileName name}}Model({
-    DATA_BITS: 1,
+describe('{{fileName name}}Model', () => {
+  it('should have 1 input and 1 output port', () => {
+    const model = new {{fileName name}}Model({
+      DATA_BITS: 1,
+    });
+
+    const { container } = render(
+      <{{fileName name}}Widget model={model} />,
+    );
+
+    const input = container.querySelector('[data-name=in]');
+    expect(input).toBeTruthy();
+
+    const output = container.querySelector('[data-name=out]');
+    expect(output).toBeTruthy();
   });
-
-  const { container } = render(
-    <{{fileName name}}Widget model={model} />,
-  );
-
-  const input = container.querySelector('[data-name=in]');
-  expect(input).toBeTruthy();
-
-  const output = container.querySelector('[data-name=out]');
-  expect(output).toBeTruthy();
 });

--- a/packages/@logossim/component-creator/templates/Gate/__tests__/GateModel.test.hbs
+++ b/packages/@logossim/component-creator/templates/Gate/__tests__/GateModel.test.hbs
@@ -1,11 +1,9 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render } from '../../testUtils';
 
 import {{fileName name}}Model from '../{{fileName name}}Model';
 import {{fileName name}}Widget from '../{{fileName name}}Widget';
-
-const { engine } = global;
 
 it('should have 1 input and 1 output port', () => {
   const model = new {{fileName name}}Model({
@@ -13,7 +11,7 @@ it('should have 1 input and 1 output port', () => {
   });
 
   const { container } = render(
-    <{{fileName name}}Widget model={model} engine={engine} />,
+    <{{fileName name}}Widget model={model} />,
   );
 
   const input = container.querySelector('[data-name=in]');

--- a/packages/@logossim/component-creator/templates/Gate/__tests__/GateWidget.test.hbs
+++ b/packages/@logossim/component-creator/templates/Gate/__tests__/GateWidget.test.hbs
@@ -1,22 +1,23 @@
 import React from 'react';
 
 import { render } from '../../testUtils';
-
 import {{fileName name}}Model from '../{{fileName name}}Model';
 import {{fileName name}}Widget from '../{{fileName name}}Widget';
 
-it('should have 1 input and 1 output port', () => {
-  const model = new {{fileName name}}Model({
-    DATA_BITS: 1,
+describe('{{fileName name}}Model', () => {
+  it('should have 1 input and 1 output port', () => {
+    const model = new {{fileName name}}Model({
+      DATA_BITS: 1,
+    });
+
+    const { container } = render(
+      <{{fileName name}}Widget model={model} />,
+    );
+
+    const input = container.querySelector('[data-name=in]');
+    expect(input).toBeTruthy();
+
+    const output = container.querySelector('[data-name=out]');
+    expect(output).toBeTruthy();
   });
-
-  const { container } = render(
-    <{{fileName name}}Widget model={model} />,
-  );
-
-  const input = container.querySelector('[data-name=in]');
-  expect(input).toBeTruthy();
-
-  const output = container.querySelector('[data-name=out]');
-  expect(output).toBeTruthy();
 });

--- a/packages/@logossim/component-creator/templates/Gate/__tests__/GateWidget.test.hbs
+++ b/packages/@logossim/component-creator/templates/Gate/__tests__/GateWidget.test.hbs
@@ -1,11 +1,9 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render } from '../../testUtils';
 
 import {{fileName name}}Model from '../{{fileName name}}Model';
 import {{fileName name}}Widget from '../{{fileName name}}Widget';
-
-const { engine } = global;
 
 it('should have 1 input and 1 output port', () => {
   const model = new {{fileName name}}Model({
@@ -13,7 +11,7 @@ it('should have 1 input and 1 output port', () => {
   });
 
   const { container } = render(
-    <{{fileName name}}Widget model={model} engine={engine} />,
+    <{{fileName name}}Widget model={model} />,
   );
 
   const input = container.querySelector('[data-name=in]');

--- a/packages/@logossim/component-creator/templates/Output/OutputModel.hbs
+++ b/packages/@logossim/component-creator/templates/Output/OutputModel.hbs
@@ -12,7 +12,10 @@ export default class {{fileName name}}Model extends BaseModel {
   }
 
   getInput() {
-    return this.getPort('in').getValue() || 0;
+    const value = this.getPort('in').getValue();
+
+    if (!value) return 0;
+    return value[0];
   }
 
   isActive() {

--- a/packages/@logossim/component-creator/templates/Output/OutputWidget.hbs
+++ b/packages/@logossim/component-creator/templates/Output/OutputWidget.hbs
@@ -30,7 +30,7 @@ export const Shape = styled.div`
 `;
 
 const {{fileName name}}Widget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
   } = model;
@@ -45,7 +45,6 @@ const {{fileName name}}Widget = props => {
       <PositionedPort
         name="in"
         model={model}
-        engine={engine}
       />
     </Shape>
   );

--- a/packages/@logossim/component-creator/templates/Output/OutputWidget.hbs
+++ b/packages/@logossim/component-creator/templates/Output/OutputWidget.hbs
@@ -42,10 +42,7 @@ const {{fileName name}}Widget = props => {
       isActive={model.isActive()}
       data-testid="shape"
     >
-      <PositionedPort
-        name="in"
-        model={model}
-      />
+      <PositionedPort name="in" />
     </Shape>
   );
 };

--- a/packages/@logossim/component-creator/templates/Output/OutputWidget.hbs
+++ b/packages/@logossim/component-creator/templates/Output/OutputWidget.hbs
@@ -45,7 +45,6 @@ const {{fileName name}}Widget = props => {
       <PositionedPort
         name="in"
         model={model}
-        port={model.getPort('in')}
         engine={engine}
       />
     </Shape>

--- a/packages/@logossim/component-creator/templates/Output/__tests__/OutputModel.test.hbs
+++ b/packages/@logossim/component-creator/templates/Output/__tests__/OutputModel.test.hbs
@@ -2,11 +2,13 @@ import {{fileName name}}Model from '../{{fileName name}}Model';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const spy = jest.spyOn({{fileName name}}Model.prototype, 'addInputPort');
-  spy.mockImplementation(addPort);
+describe('{{fileName name}}Model', () => {
+  it('should add ports on initialization', () => {
+    const spy = jest.spyOn({{fileName name}}Model.prototype, 'addInputPort');
+    spy.mockImplementation(addPort);
 
-  new {{fileName name}}Model();
+    new {{fileName name}}Model();
 
-  expect(spy).toHaveBeenCalledWith('in');
+    expect(spy).toHaveBeenCalledWith('in');
+  });
 });

--- a/packages/@logossim/component-creator/templates/Output/__tests__/OutputModel.test.hbs
+++ b/packages/@logossim/component-creator/templates/Output/__tests__/OutputModel.test.hbs
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import {{fileName name}}Model from '../{{fileName name}}Model';
 
 const { addPort } = global;

--- a/packages/@logossim/component-creator/templates/Output/__tests__/OutputWidget.test.hbs
+++ b/packages/@logossim/component-creator/templates/Output/__tests__/OutputWidget.test.hbs
@@ -1,17 +1,15 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render } from '../../testUtils';
 
 import {{fileName name}}Model from '../{{fileName name}}Model';
 import {{fileName name}}Widget from '../{{fileName name}}Widget';
-
-const { engine } = global;
 
 it('should have 1 input port', () => {
   const model = new {{fileName name}}Model();
 
   const { container } = render(
-    <{{fileName name}}Widget model={model} engine={engine} />,
+    <{{fileName name}}Widget model={model} />,
   );
 
   const ports = container.querySelectorAll('[data-name=in]');
@@ -28,7 +26,7 @@ it('should display correct color when configured with active on high and value i
   spy.mockImplementation(() => 0);
 
   const { getByTestId } = render(
-    <{{fileName name}}Widget model={model} engine={engine} />,
+    <{{fileName name}}Widget model={model} />,
   );
   const shape = getByTestId('shape');
 
@@ -45,7 +43,7 @@ it('should display correct color when configured with active on high and value i
   spy.mockImplementation(() => 1);
 
   const { getByTestId } = render(
-    <{{fileName name}}Widget model={model} engine={engine} />,
+    <{{fileName name}}Widget model={model} />,
   );
   const shape = getByTestId('shape');
 
@@ -62,7 +60,7 @@ it('should display correct color when configured with active on low and value is
   spy.mockImplementation(() => 0);
 
   const { getByTestId } = render(
-    <{{fileName name}}Widget model={model} engine={engine} />,
+    <{{fileName name}}Widget model={model} />,
   );
   const shape = getByTestId('shape');
 
@@ -79,7 +77,7 @@ it('should display correct color when configured with active on low and value is
   spy.mockImplementation(() => 1);
 
   const { getByTestId } = render(
-    <{{fileName name}}Widget model={model} engine={engine} />,
+    <{{fileName name}}Widget model={model} />,
   );
   const shape = getByTestId('shape');
 

--- a/packages/@logossim/component-creator/templates/Output/__tests__/OutputWidget.test.hbs
+++ b/packages/@logossim/component-creator/templates/Output/__tests__/OutputWidget.test.hbs
@@ -1,85 +1,86 @@
 import React from 'react';
 
 import { render } from '../../testUtils';
-
 import {{fileName name}}Model from '../{{fileName name}}Model';
 import {{fileName name}}Widget from '../{{fileName name}}Widget';
 
-it('should have 1 input port', () => {
-  const model = new {{fileName name}}Model();
+describe('{{fileName name}}Widget', () => {
+  it('should have 1 input port', () => {
+    const model = new {{fileName name}}Model();
 
-  const { container } = render(
-    <{{fileName name}}Widget model={model} />,
-  );
+    const { container } = render(
+      <{{fileName name}}Widget model={model} />,
+    );
 
-  const ports = container.querySelectorAll('[data-name=in]');
-  expect(ports).toHaveLength(1);
-});
-
-it('should display correct color when configured with active on high and value is low', () => {
-  const model = new {{fileName name}}Model({
-    ACTIVE_WHEN: 'HIGH',
-    ON_COLOR: '#ff0000',
-    OFF_COLOR: '#000000',
+    const ports = container.querySelectorAll('[data-name=in]');
+    expect(ports).toHaveLength(1);
   });
-  const spy = jest.spyOn(model, 'getInput');
-  spy.mockImplementation(() => 0);
 
-  const { getByTestId } = render(
-    <{{fileName name}}Widget model={model} />,
-  );
-  const shape = getByTestId('shape');
+  it('should display correct color when configured with active on high and value is low', () => {
+    const model = new {{fileName name}}Model({
+      ACTIVE_WHEN: 'HIGH',
+      ON_COLOR: '#ff0000',
+      OFF_COLOR: '#000000',
+    });
+    const spy = jest.spyOn(model, 'getInput');
+    spy.mockImplementation(() => 0);
 
-  expect(shape).toHaveAttribute('color', '#000000');
-});
+    const { getByTestId } = render(
+      <{{fileName name}}Widget model={model} />,
+    );
+    const shape = getByTestId('shape');
 
-it('should display correct color when configured with active on high and value is high', () => {
-  const model = new {{fileName name}}Model({
-    ACTIVE_WHEN: 'HIGH',
-    ON_COLOR: '#ff0000',
-    OFF_COLOR: '#000000',
+    expect(shape).toHaveAttribute('color', '#000000');
   });
-  const spy = jest.spyOn(model, 'getInput');
-  spy.mockImplementation(() => 1);
 
-  const { getByTestId } = render(
-    <{{fileName name}}Widget model={model} />,
-  );
-  const shape = getByTestId('shape');
+  it('should display correct color when configured with active on high and value is high', () => {
+    const model = new {{fileName name}}Model({
+      ACTIVE_WHEN: 'HIGH',
+      ON_COLOR: '#ff0000',
+      OFF_COLOR: '#000000',
+    });
+    const spy = jest.spyOn(model, 'getInput');
+    spy.mockImplementation(() => 1);
 
-  expect(shape).toHaveAttribute('color', '#ff0000');
-});
+    const { getByTestId } = render(
+      <{{fileName name}}Widget model={model} />,
+    );
+    const shape = getByTestId('shape');
 
-it('should display correct color when configured with active on low and value is low', () => {
-  const model = new {{fileName name}}Model({
-    ACTIVE_WHEN: 'LOW',
-    ON_COLOR: '#ff0000',
-    OFF_COLOR: '#000000',
+    expect(shape).toHaveAttribute('color', '#ff0000');
   });
-  const spy = jest.spyOn(model, 'getInput');
-  spy.mockImplementation(() => 0);
 
-  const { getByTestId } = render(
-    <{{fileName name}}Widget model={model} />,
-  );
-  const shape = getByTestId('shape');
+  it('should display correct color when configured with active on low and value is low', () => {
+    const model = new {{fileName name}}Model({
+      ACTIVE_WHEN: 'LOW',
+      ON_COLOR: '#ff0000',
+      OFF_COLOR: '#000000',
+    });
+    const spy = jest.spyOn(model, 'getInput');
+    spy.mockImplementation(() => 0);
 
-  expect(shape).toHaveAttribute('color', '#ff0000');
-});
+    const { getByTestId } = render(
+      <{{fileName name}}Widget model={model} />,
+    );
+    const shape = getByTestId('shape');
 
-it('should display correct color when configured with active on low and value is high', () => {
-  const model = new {{fileName name}}Model({
-    ACTIVE_WHEN: 'LOW',
-    ON_COLOR: '#ff0000',
-    OFF_COLOR: '#000000',
+    expect(shape).toHaveAttribute('color', '#ff0000');
   });
-  const spy = jest.spyOn(model, 'getInput');
-  spy.mockImplementation(() => 1);
 
-  const { getByTestId } = render(
-    <{{fileName name}}Widget model={model} />,
-  );
-  const shape = getByTestId('shape');
+  it('should display correct color when configured with active on low and value is high', () => {
+    const model = new {{fileName name}}Model({
+      ACTIVE_WHEN: 'LOW',
+      ON_COLOR: '#ff0000',
+      OFF_COLOR: '#000000',
+    });
+    const spy = jest.spyOn(model, 'getInput');
+    spy.mockImplementation(() => 1);
 
-  expect(shape).toHaveAttribute('color', '#000000');
+    const { getByTestId } = render(
+      <{{fileName name}}Widget model={model} />,
+    );
+    const shape = getByTestId('shape');
+
+    expect(shape).toHaveAttribute('color', '#000000');
+  });
 });

--- a/packages/@logossim/component-creator/utils/basePrompts.js
+++ b/packages/@logossim/component-creator/utils/basePrompts.js
@@ -16,7 +16,14 @@ const basePrompts = [
     type: 'list',
     name: 'group',
     message: 'In which group this component should be added?',
-    choices: ['Input & output', 'Logic gates', 'Wiring', 'Plexers'],
+    choices: [
+      'Input & output',
+      'Logic gates',
+      'Wiring',
+      'Plexers',
+      'Memory',
+      'Miscellaneous',
+    ],
   },
 ];
 

--- a/packages/@logossim/components/And/AndModel.js
+++ b/packages/@logossim/components/And/AndModel.js
@@ -5,17 +5,34 @@ export default class AndModel extends BaseModel {
     const INPUT_PORTS_NUMBER = Number(
       configurations.INPUT_PORTS_NUMBER,
     );
-    const DATA_BITS = Number(configurations.DATA_BITS);
+    this.dataBits = Number(configurations.DATA_BITS);
 
     for (let i = 0; i < INPUT_PORTS_NUMBER; i += 1) {
-      this.addInputPort(`in${i}`, { bits: DATA_BITS });
+      this.addInputPort(`in${i}`, { bits: this.dataBits });
     }
-    this.addOutputPort('out', { bits: DATA_BITS });
+    this.addOutputPort('out', { bits: this.dataBits });
+  }
+
+  executeBit(bits) {
+    if (bits.every(bit => bit === 1)) return 1;
+    if (bits.some(bit => bit === 0)) return 0;
+    return 'e';
   }
 
   step(input) {
     return {
-      out: Object.values(input).reduce((acc, curr) => acc & curr),
+      out: Object.values(input)
+        .map(value => value.asArray(this.dataBits))
+        .transpose()
+        .map(this.executeBit),
     };
+  }
+
+  stepFloating(input) {
+    return this.step(input);
+  }
+
+  stepError(input) {
+    return this.step(input);
   }
 }

--- a/packages/@logossim/components/And/AndModel.js
+++ b/packages/@logossim/components/And/AndModel.js
@@ -8,9 +8,9 @@ export default class AndModel extends BaseModel {
     const DATA_BITS = Number(configurations.DATA_BITS);
 
     for (let i = 0; i < INPUT_PORTS_NUMBER; i += 1) {
-      this.addInputPort(`in${i}`, DATA_BITS);
+      this.addInputPort(`in${i}`, { bits: DATA_BITS });
     }
-    this.addOutputPort('out', DATA_BITS);
+    this.addOutputPort('out', { bits: DATA_BITS });
   }
 
   step(input) {

--- a/packages/@logossim/components/And/AndWidget.jsx
+++ b/packages/@logossim/components/And/AndWidget.jsx
@@ -76,11 +76,10 @@ const AndWidget = props => {
         <PositionedPort
           key={port.getName()}
           name={port.getName()}
-          model={model}
           position={portPositions[i]}
         />
       ))}
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="out" />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/And/AndWidget.jsx
+++ b/packages/@logossim/components/And/AndWidget.jsx
@@ -77,17 +77,11 @@ const AndWidget = props => {
           key={port.getName()}
           name={port.getName()}
           model={model}
-          port={port}
           engine={engine}
           position={portPositions[i]}
         />
       ))}
-      <PositionedPort
-        name="out"
-        model={model}
-        port={model.getPort('out')}
-        engine={engine}
-      />
+      <PositionedPort name="out" model={model} engine={engine} />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/And/AndWidget.jsx
+++ b/packages/@logossim/components/And/AndWidget.jsx
@@ -61,7 +61,7 @@ export const Shape = ({ size = 90 }) => (
 );
 
 const AndWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
 
   const inputPorts = Object.values(model.getInputPorts());
   const portPositions = distributePorts(inputPorts.length);
@@ -77,11 +77,10 @@ const AndWidget = props => {
           key={port.getName()}
           name={port.getName()}
           model={model}
-          engine={engine}
           position={portPositions[i]}
         />
       ))}
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/And/__tests__/AndModel.test.js
+++ b/packages/@logossim/components/And/__tests__/AndModel.test.js
@@ -32,11 +32,11 @@ it("should return 0 when there's a 0 input", () => {
   });
 
   expect(
-    model.stepAndMask({
-      in0: 0,
+    model.step({
+      in0: 1,
       in1: 0,
-      in2: 0,
-      in3: 0,
+      in2: 1,
+      in3: 1,
     }),
   ).toEqual({ out: [0] });
 });
@@ -48,13 +48,41 @@ it('should return 1 when all inputs are 1', () => {
   });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 1,
       in1: 1,
       in2: 1,
       in3: 1,
     }),
   ).toEqual({ out: [1] });
+});
+
+it("should return error when there's no 0 and there's one floating input", () => {
+  const model = new AndModel({
+    INPUT_PORTS_NUMBER: 2,
+    DATA_BITS: 1,
+  });
+
+  expect(
+    model.stepFloating({
+      in0: [1],
+      in1: ['x'],
+    }),
+  ).toEqual({ out: ['e'] });
+});
+
+it("should return error when there's no 0 and there's one error input", () => {
+  const model = new AndModel({
+    INPUT_PORTS_NUMBER: 2,
+    DATA_BITS: 1,
+  });
+
+  expect(
+    model.stepError({
+      in0: [1],
+      in1: ['e'],
+    }),
+  ).toEqual({ out: ['e'] });
 });
 
 it('should return bitwise AND for multiple data bits', () => {
@@ -66,7 +94,7 @@ it('should return bitwise AND for multiple data bits', () => {
   });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 0b0001,
       in1: 0b0011,
       in2: 0b0101,

--- a/packages/@logossim/components/And/__tests__/AndModel.test.js
+++ b/packages/@logossim/components/And/__tests__/AndModel.test.js
@@ -20,9 +20,11 @@ it('should add ports on initialization', () => {
     DATA_BITS: 1,
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', 1);
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
   [...Array(16).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, 1);
+    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
+      bits: 1,
+    });
   });
 });
 

--- a/packages/@logossim/components/And/__tests__/AndModel.test.js
+++ b/packages/@logossim/components/And/__tests__/AndModel.test.js
@@ -2,103 +2,108 @@ import AndModel from '../AndModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const addInputSpy = jest.spyOn(AndModel.prototype, 'addInputPort');
-  addInputSpy.mockImplementation(addPort);
+describe('AndModel', () => {
+  it('should add ports on initialization', () => {
+    const addInputSpy = jest.spyOn(
+      AndModel.prototype,
+      'addInputPort',
+    );
+    addInputSpy.mockImplementation(addPort);
 
-  const addOutputSpy = jest.spyOn(
-    AndModel.prototype,
-    'addOutputPort',
-  );
-  addOutputSpy.mockImplementation(addPort);
+    const addOutputSpy = jest.spyOn(
+      AndModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  new AndModel({
-    INPUT_PORTS_NUMBER: 16,
-    DATA_BITS: 1,
-  });
+    new AndModel({
+      INPUT_PORTS_NUMBER: 16,
+      DATA_BITS: 1,
+    });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
-  [...Array(16).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
-      bits: 1,
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
+    [...Array(16).keys()].forEach(i => {
+      expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
+        bits: 1,
+      });
     });
   });
-});
 
-it("should return 0 when there's a 0 input", () => {
-  const model = new AndModel({
-    INPUT_PORTS_NUMBER: 4,
-    DATA_BITS: 1,
+  it("should return 0 when there's a 0 input", () => {
+    const model = new AndModel({
+      INPUT_PORTS_NUMBER: 4,
+      DATA_BITS: 1,
+    });
+
+    expect(
+      model.step({
+        in0: 1,
+        in1: 0,
+        in2: 1,
+        in3: 1,
+      }),
+    ).toEqual({ out: [0] });
   });
 
-  expect(
-    model.step({
-      in0: 1,
-      in1: 0,
-      in2: 1,
-      in3: 1,
-    }),
-  ).toEqual({ out: [0] });
-});
+  it('should return 1 when all inputs are 1', () => {
+    const model = new AndModel({
+      INPUT_PORTS_NUMBER: 4,
+      DATA_BITS: 1,
+    });
 
-it('should return 1 when all inputs are 1', () => {
-  const model = new AndModel({
-    INPUT_PORTS_NUMBER: 4,
-    DATA_BITS: 1,
+    expect(
+      model.step({
+        in0: 1,
+        in1: 1,
+        in2: 1,
+        in3: 1,
+      }),
+    ).toEqual({ out: [1] });
   });
 
-  expect(
-    model.step({
-      in0: 1,
-      in1: 1,
-      in2: 1,
-      in3: 1,
-    }),
-  ).toEqual({ out: [1] });
-});
+  it("should return error when there's no 0 and there's one floating input", () => {
+    const model = new AndModel({
+      INPUT_PORTS_NUMBER: 2,
+      DATA_BITS: 1,
+    });
 
-it("should return error when there's no 0 and there's one floating input", () => {
-  const model = new AndModel({
-    INPUT_PORTS_NUMBER: 2,
-    DATA_BITS: 1,
+    expect(
+      model.stepFloating({
+        in0: [1],
+        in1: ['x'],
+      }),
+    ).toEqual({ out: ['e'] });
   });
 
-  expect(
-    model.stepFloating({
-      in0: [1],
-      in1: ['x'],
-    }),
-  ).toEqual({ out: ['e'] });
-});
+  it("should return error when there's no 0 and there's one error input", () => {
+    const model = new AndModel({
+      INPUT_PORTS_NUMBER: 2,
+      DATA_BITS: 1,
+    });
 
-it("should return error when there's no 0 and there's one error input", () => {
-  const model = new AndModel({
-    INPUT_PORTS_NUMBER: 2,
-    DATA_BITS: 1,
+    expect(
+      model.stepError({
+        in0: [1],
+        in1: ['e'],
+      }),
+    ).toEqual({ out: ['e'] });
   });
 
-  expect(
-    model.stepError({
-      in0: [1],
-      in1: ['e'],
-    }),
-  ).toEqual({ out: ['e'] });
-});
+  it('should return bitwise AND for multiple data bits', () => {
+    const DATA_BITS = 4;
 
-it('should return bitwise AND for multiple data bits', () => {
-  const DATA_BITS = 4;
+    const model = new AndModel({
+      INPUT_PORTS_NUMBER: 4,
+      DATA_BITS,
+    });
 
-  const model = new AndModel({
-    INPUT_PORTS_NUMBER: 4,
-    DATA_BITS,
+    expect(
+      model.step({
+        in0: 0b0001,
+        in1: 0b0011,
+        in2: 0b0101,
+        in3: 0b1001,
+      }),
+    ).toEqual({ out: (0b0001).asArray(DATA_BITS) });
   });
-
-  expect(
-    model.step({
-      in0: 0b0001,
-      in1: 0b0011,
-      in2: 0b0101,
-      in3: 0b1001,
-    }),
-  ).toEqual({ out: (0b0001).asArray(DATA_BITS) });
 });

--- a/packages/@logossim/components/And/__tests__/AndModel.test.js
+++ b/packages/@logossim/components/And/__tests__/AndModel.test.js
@@ -1,6 +1,3 @@
-/* eslint-disable no-new */
-import { convertNumberValueToArray } from '@logossim/core/Simulation/utils';
-
 import AndModel from '../AndModel';
 
 const { addPort } = global;
@@ -75,5 +72,5 @@ it('should return bitwise AND for multiple data bits', () => {
       in2: 0b0101,
       in3: 0b1001,
     }),
-  ).toEqual({ out: convertNumberValueToArray(0b0001, DATA_BITS) });
+  ).toEqual({ out: (0b0001).asArray(DATA_BITS) });
 });

--- a/packages/@logossim/components/And/__tests__/AndWidget.test.jsx
+++ b/packages/@logossim/components/And/__tests__/AndWidget.test.jsx
@@ -1,20 +1,15 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import AndModel from '../AndModel';
 import AndWidget from '../AndWidget';
-
-const { engine } = global;
 
 it('should have 1 output port', () => {
   const model = new AndModel({
     DATA_BITS: 1,
   });
 
-  const { container } = render(
-    <AndWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<AndWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name=out]');
   expect(ports).toHaveLength(1);
@@ -26,9 +21,7 @@ it('should have the amount of input ports determined by configuration', () => {
     DATA_BITS: 1,
   });
 
-  const { container } = render(
-    <AndWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<AndWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name^=in]');
   expect(ports).toHaveLength(16);

--- a/packages/@logossim/components/And/__tests__/AndWidget.test.jsx
+++ b/packages/@logossim/components/And/__tests__/AndWidget.test.jsx
@@ -4,25 +4,27 @@ import { render } from '../../testUtils';
 import AndModel from '../AndModel';
 import AndWidget from '../AndWidget';
 
-it('should have 1 output port', () => {
-  const model = new AndModel({
-    DATA_BITS: 1,
+describe('AndWidget', () => {
+  it('should have 1 output port', () => {
+    const model = new AndModel({
+      DATA_BITS: 1,
+    });
+
+    const { container } = render(<AndWidget model={model} />);
+
+    const ports = container.querySelectorAll('[data-name=out]');
+    expect(ports).toHaveLength(1);
   });
 
-  const { container } = render(<AndWidget model={model} />);
+  it('should have the amount of input ports determined by configuration', () => {
+    const model = new AndModel({
+      INPUT_PORTS_NUMBER: 16,
+      DATA_BITS: 1,
+    });
 
-  const ports = container.querySelectorAll('[data-name=out]');
-  expect(ports).toHaveLength(1);
-});
+    const { container } = render(<AndWidget model={model} />);
 
-it('should have the amount of input ports determined by configuration', () => {
-  const model = new AndModel({
-    INPUT_PORTS_NUMBER: 16,
-    DATA_BITS: 1,
+    const ports = container.querySelectorAll('[data-name^=in]');
+    expect(ports).toHaveLength(16);
   });
-
-  const { container } = render(<AndWidget model={model} />);
-
-  const ports = container.querySelectorAll('[data-name^=in]');
-  expect(ports).toHaveLength(16);
 });

--- a/packages/@logossim/components/Buffer/BufferModel.js
+++ b/packages/@logossim/components/Buffer/BufferModel.js
@@ -4,8 +4,8 @@ export default class BufferModel extends BaseModel {
   initialize(configurations) {
     const DATA_BITS = Number(configurations.DATA_BITS);
 
-    this.addInputPort('in', DATA_BITS);
-    this.addOutputPort('out', DATA_BITS);
+    this.addInputPort('in', { bits: DATA_BITS });
+    this.addOutputPort('out', { bits: DATA_BITS });
   }
 
   step(input) {

--- a/packages/@logossim/components/Buffer/BufferWidget.jsx
+++ b/packages/@logossim/components/Buffer/BufferWidget.jsx
@@ -51,15 +51,15 @@ export const Shape = ({ size = 30 }) => (
 );
 
 const BufferWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
   } = model;
 
   return (
     <Wrapper selected={selected}>
-      <PositionedPort name="in" model={model} engine={engine} />
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="in" model={model} />
+      <PositionedPort name="out" model={model} />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/Buffer/BufferWidget.jsx
+++ b/packages/@logossim/components/Buffer/BufferWidget.jsx
@@ -58,18 +58,8 @@ const BufferWidget = props => {
 
   return (
     <Wrapper selected={selected}>
-      <PositionedPort
-        name="in"
-        model={model}
-        port={model.getPort('in')}
-        engine={engine}
-      />
-      <PositionedPort
-        name="out"
-        model={model}
-        port={model.getPort('out')}
-        engine={engine}
-      />
+      <PositionedPort name="in" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} engine={engine} />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/Buffer/BufferWidget.jsx
+++ b/packages/@logossim/components/Buffer/BufferWidget.jsx
@@ -58,8 +58,8 @@ const BufferWidget = props => {
 
   return (
     <Wrapper selected={selected}>
-      <PositionedPort name="in" model={model} />
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="in" />
+      <PositionedPort name="out" />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/Buffer/__tests__/BufferModel.test.js
+++ b/packages/@logossim/components/Buffer/__tests__/BufferModel.test.js
@@ -22,8 +22,8 @@ it('should add ports on initialization', () => {
     DATA_BITS: 4,
   });
 
-  expect(addInputSpy).toHaveBeenCalledWith('in', 4);
-  expect(addOutputSpy).toHaveBeenCalledWith('out', 4);
+  expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 4 });
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
 });
 
 it('should return the value unmodified', () => {

--- a/packages/@logossim/components/Buffer/__tests__/BufferModel.test.js
+++ b/packages/@logossim/components/Buffer/__tests__/BufferModel.test.js
@@ -29,30 +29,28 @@ it('should return the value unmodified', () => {
   });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in: 0,
     }),
-  ).toEqual({ out: [0] });
+  ).toEqual({ out: 0 });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in: 1,
     }),
-  ).toEqual({ out: [1] });
+  ).toEqual({ out: 1 });
 });
 
 it('should return the value unmodified for multiple bits', () => {
-  const DATA_BITS = 8;
-
   const model = new BufferModel({
-    DATA_BITS,
+    DATA_BITS: 8,
   });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in: 0b0101_1010,
     }),
   ).toEqual({
-    out: (0b0101_1010).asArray(DATA_BITS),
+    out: 0b0101_1010,
   });
 });

--- a/packages/@logossim/components/Buffer/__tests__/BufferModel.test.js
+++ b/packages/@logossim/components/Buffer/__tests__/BufferModel.test.js
@@ -2,55 +2,57 @@ import BufferModel from '../BufferModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const addInputSpy = jest.spyOn(
-    BufferModel.prototype,
-    'addInputPort',
-  );
-  addInputSpy.mockImplementation(addPort);
+describe('BufferModel', () => {
+  it('should add ports on initialization', () => {
+    const addInputSpy = jest.spyOn(
+      BufferModel.prototype,
+      'addInputPort',
+    );
+    addInputSpy.mockImplementation(addPort);
 
-  const addOutputSpy = jest.spyOn(
-    BufferModel.prototype,
-    'addOutputPort',
-  );
-  addOutputSpy.mockImplementation(addPort);
+    const addOutputSpy = jest.spyOn(
+      BufferModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  new BufferModel({
-    DATA_BITS: 4,
+    new BufferModel({
+      DATA_BITS: 4,
+    });
+
+    expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 4 });
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
   });
 
-  expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 4 });
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
-});
+  it('should return the value unmodified', () => {
+    const model = new BufferModel({
+      DATA_BITS: 1,
+    });
 
-it('should return the value unmodified', () => {
-  const model = new BufferModel({
-    DATA_BITS: 1,
+    expect(
+      model.step({
+        in: 0,
+      }),
+    ).toEqual({ out: 0 });
+
+    expect(
+      model.step({
+        in: 1,
+      }),
+    ).toEqual({ out: 1 });
   });
 
-  expect(
-    model.step({
-      in: 0,
-    }),
-  ).toEqual({ out: 0 });
+  it('should return the value unmodified for multiple bits', () => {
+    const model = new BufferModel({
+      DATA_BITS: 8,
+    });
 
-  expect(
-    model.step({
-      in: 1,
-    }),
-  ).toEqual({ out: 1 });
-});
-
-it('should return the value unmodified for multiple bits', () => {
-  const model = new BufferModel({
-    DATA_BITS: 8,
-  });
-
-  expect(
-    model.step({
-      in: 0b0101_1010,
-    }),
-  ).toEqual({
-    out: 0b0101_1010,
+    expect(
+      model.step({
+        in: 0b0101_1010,
+      }),
+    ).toEqual({
+      out: 0b0101_1010,
+    });
   });
 });

--- a/packages/@logossim/components/Buffer/__tests__/BufferModel.test.js
+++ b/packages/@logossim/components/Buffer/__tests__/BufferModel.test.js
@@ -1,6 +1,3 @@
-/* eslint-disable no-new */
-import { convertNumberValueToArray } from '@logossim/core/Simulation/utils';
-
 import BufferModel from '../BufferModel';
 
 const { addPort } = global;
@@ -56,6 +53,6 @@ it('should return the value unmodified for multiple bits', () => {
       in: 0b0101_1010,
     }),
   ).toEqual({
-    out: convertNumberValueToArray(0b0101_1010, DATA_BITS),
+    out: (0b0101_1010).asArray(DATA_BITS),
   });
 });

--- a/packages/@logossim/components/Buffer/__tests__/BufferWidget.test.jsx
+++ b/packages/@logossim/components/Buffer/__tests__/BufferWidget.test.jsx
@@ -1,20 +1,16 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render } from '../../testUtils';
 
 import BufferModel from '../BufferModel';
 import BufferWidget from '../BufferWidget';
-
-const { engine } = global;
 
 it('should have 1 input and 1 output port', () => {
   const model = new BufferModel({
     DATA_BITS: 1,
   });
 
-  const { container } = render(
-    <BufferWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<BufferWidget model={model} />);
 
   const input = container.querySelector('[data-name=in]');
   expect(input).toBeTruthy();

--- a/packages/@logossim/components/Buffer/__tests__/BufferWidget.test.jsx
+++ b/packages/@logossim/components/Buffer/__tests__/BufferWidget.test.jsx
@@ -1,20 +1,21 @@
 import React from 'react';
 
 import { render } from '../../testUtils';
-
 import BufferModel from '../BufferModel';
 import BufferWidget from '../BufferWidget';
 
-it('should have 1 input and 1 output port', () => {
-  const model = new BufferModel({
-    DATA_BITS: 1,
+describe('BufferWidget', () => {
+  it('should have 1 input and 1 output port', () => {
+    const model = new BufferModel({
+      DATA_BITS: 1,
+    });
+
+    const { container } = render(<BufferWidget model={model} />);
+
+    const input = container.querySelector('[data-name=in]');
+    expect(input).toBeTruthy();
+
+    const output = container.querySelector('[data-name=out]');
+    expect(output).toBeTruthy();
   });
-
-  const { container } = render(<BufferWidget model={model} />);
-
-  const input = container.querySelector('[data-name=in]');
-  expect(input).toBeTruthy();
-
-  const output = container.querySelector('[data-name=out]');
-  expect(output).toBeTruthy();
 });

--- a/packages/@logossim/components/Button/ButtonWidget.jsx
+++ b/packages/@logossim/components/Button/ButtonWidget.jsx
@@ -57,7 +57,7 @@ const PositionedPort = styled(Port)`
 `;
 
 const ButtonWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
   } = model;
@@ -81,7 +81,7 @@ const ButtonWidget = props => {
 
   return (
     <Shape selected={selected}>
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} />
       <Button
         ref={buttonRef}
         onMouseDown={() => model.onClick()}

--- a/packages/@logossim/components/Button/ButtonWidget.jsx
+++ b/packages/@logossim/components/Button/ButtonWidget.jsx
@@ -81,7 +81,7 @@ const ButtonWidget = props => {
 
   return (
     <Shape selected={selected}>
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="out" />
       <Button
         ref={buttonRef}
         onMouseDown={() => model.onClick()}

--- a/packages/@logossim/components/Button/ButtonWidget.jsx
+++ b/packages/@logossim/components/Button/ButtonWidget.jsx
@@ -81,12 +81,7 @@ const ButtonWidget = props => {
 
   return (
     <Shape selected={selected}>
-      <PositionedPort
-        name="out"
-        model={model}
-        port={model.getPort('out')}
-        engine={engine}
-      />
+      <PositionedPort name="out" model={model} engine={engine} />
       <Button
         ref={buttonRef}
         onMouseDown={() => model.onClick()}

--- a/packages/@logossim/components/Button/__tests__/ButtonModel.test.js
+++ b/packages/@logossim/components/Button/__tests__/ButtonModel.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import ButtonModel from '../ButtonModel';
 
 const { addPort } = global;

--- a/packages/@logossim/components/Button/__tests__/ButtonModel.test.js
+++ b/packages/@logossim/components/Button/__tests__/ButtonModel.test.js
@@ -2,37 +2,39 @@ import ButtonModel from '../ButtonModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const spy = jest.spyOn(ButtonModel.prototype, 'addOutputPort');
-  spy.mockImplementation(addPort);
+describe('ButtonModel', () => {
+  it('should add ports on initialization', () => {
+    const spy = jest.spyOn(ButtonModel.prototype, 'addOutputPort');
+    spy.mockImplementation(addPort);
 
-  new ButtonModel();
+    new ButtonModel();
 
-  expect(spy).toHaveBeenCalledWith('out');
-});
+    expect(spy).toHaveBeenCalledWith('out');
+  });
 
-it('should emit on simulation start', () => {
-  const model = new ButtonModel();
-  const spy = jest.spyOn(model, 'emit');
-  model.onSimulationStart();
+  it('should emit on simulation start', () => {
+    const model = new ButtonModel();
+    const spy = jest.spyOn(model, 'emit');
+    model.onSimulationStart();
 
-  expect(spy).toHaveBeenCalledWith({ out: 0 });
-});
+    expect(spy).toHaveBeenCalledWith({ out: 0 });
+  });
 
-it('should emit correctly on click', () => {
-  const model = new ButtonModel();
-  const emitSpy = jest.spyOn(model, 'emit');
+  it('should emit correctly on click', () => {
+    const model = new ButtonModel();
+    const emitSpy = jest.spyOn(model, 'emit');
 
-  model.onClick();
+    model.onClick();
 
-  expect(emitSpy).toHaveBeenCalledWith({ out: 1 });
-});
+    expect(emitSpy).toHaveBeenCalledWith({ out: 1 });
+  });
 
-it('should emit correctly on release', () => {
-  const model = new ButtonModel();
-  const emitSpy = jest.spyOn(model, 'emit');
+  it('should emit correctly on release', () => {
+    const model = new ButtonModel();
+    const emitSpy = jest.spyOn(model, 'emit');
 
-  model.onRelease();
+    model.onRelease();
 
-  expect(emitSpy).toHaveBeenCalledWith({ out: 0 });
+    expect(emitSpy).toHaveBeenCalledWith({ out: 0 });
+  });
 });

--- a/packages/@logossim/components/Button/__tests__/ButtonWidget.test.jsx
+++ b/packages/@logossim/components/Button/__tests__/ButtonWidget.test.jsx
@@ -6,34 +6,36 @@ import { render } from '../../testUtils';
 import ButtonModel from '../ButtonModel';
 import ButtonWidget from '../ButtonWidget';
 
-it('should have 1 output port', () => {
-  const model = new ButtonModel();
+describe('ButtonWidget', () => {
+  it('should have 1 output port', () => {
+    const model = new ButtonModel();
 
-  const { container } = render(<ButtonWidget model={model} />);
+    const { container } = render(<ButtonWidget model={model} />);
 
-  const ports = container.querySelectorAll('[data-name=out]');
-  expect(ports).toHaveLength(1);
-});
+    const ports = container.querySelectorAll('[data-name=out]');
+    expect(ports).toHaveLength(1);
+  });
 
-it('should call model onClick on mouse down event', () => {
-  const model = new ButtonModel();
-  const spy = jest.spyOn(model, 'onClick');
+  it('should call model onClick on mouse down event', () => {
+    const model = new ButtonModel();
+    const spy = jest.spyOn(model, 'onClick');
 
-  const { getByRole } = render(<ButtonWidget model={model} />);
-  const button = getByRole('button');
+    const { getByRole } = render(<ButtonWidget model={model} />);
+    const button = getByRole('button');
 
-  fireEvent.mouseDown(button);
+    fireEvent.mouseDown(button);
 
-  expect(spy).toHaveBeenCalledTimes(1);
-});
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
 
-it('should call model onRelease on mouse up event', () => {
-  const model = new ButtonModel();
-  const spy = jest.spyOn(model, 'onRelease');
+  it('should call model onRelease on mouse up event', () => {
+    const model = new ButtonModel();
+    const spy = jest.spyOn(model, 'onRelease');
 
-  render(<ButtonWidget model={model} />);
+    render(<ButtonWidget model={model} />);
 
-  fireEvent.mouseUp(document.body);
+    fireEvent.mouseUp(document.body);
 
-  expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/@logossim/components/Button/__tests__/ButtonWidget.test.jsx
+++ b/packages/@logossim/components/Button/__tests__/ButtonWidget.test.jsx
@@ -1,19 +1,15 @@
 import React from 'react';
 
 import { fireEvent } from '@testing-library/dom';
-import { render } from '@testing-library/react';
 
+import { render } from '../../testUtils';
 import ButtonModel from '../ButtonModel';
 import ButtonWidget from '../ButtonWidget';
-
-const { engine } = global;
 
 it('should have 1 output port', () => {
   const model = new ButtonModel();
 
-  const { container } = render(
-    <ButtonWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<ButtonWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name=out]');
   expect(ports).toHaveLength(1);
@@ -23,9 +19,7 @@ it('should call model onClick on mouse down event', () => {
   const model = new ButtonModel();
   const spy = jest.spyOn(model, 'onClick');
 
-  const { getByRole } = render(
-    <ButtonWidget model={model} engine={engine} />,
-  );
+  const { getByRole } = render(<ButtonWidget model={model} />);
   const button = getByRole('button');
 
   fireEvent.mouseDown(button);
@@ -37,7 +31,7 @@ it('should call model onRelease on mouse up event', () => {
   const model = new ButtonModel();
   const spy = jest.spyOn(model, 'onRelease');
 
-  render(<ButtonWidget model={model} engine={engine} />);
+  render(<ButtonWidget model={model} />);
 
   fireEvent.mouseUp(document.body);
 

--- a/packages/@logossim/components/Buzzer/BuzzerModel.js
+++ b/packages/@logossim/components/Buzzer/BuzzerModel.js
@@ -10,6 +10,8 @@ export default class BuzzerModel extends BaseModel {
 
   onSimulationStart() {
     this.audio = this.createAudio(this.frequencyHz, this.waveform);
+
+    if (this.getInput() === 1) this.audio.play();
   }
 
   onSimulationPause() {
@@ -25,7 +27,10 @@ export default class BuzzerModel extends BaseModel {
   }
 
   getInput() {
-    return this.getPort('in').getValue() || [0];
+    const value = this.getPort('in').getValue();
+
+    if (!value) return 0;
+    return value[0];
   }
 
   isActive() {

--- a/packages/@logossim/components/Buzzer/BuzzerWidget.jsx
+++ b/packages/@logossim/components/Buzzer/BuzzerWidget.jsx
@@ -47,15 +47,15 @@ export const Shape = ({ selected, isActive, children }) => (
   </Body>
 );
 
-export const BuzzerWidget = props => {
-  const { model, engine } = props;
+const BuzzerWidget = props => {
+  const { model } = props;
   const {
     options: { selected },
   } = model;
 
   return (
     <Shape selected={selected} isActive={model.isActive()}>
-      <PositionedPort name="in" model={model} engine={engine} />
+      <PositionedPort name="in" model={model} />
     </Shape>
   );
 };

--- a/packages/@logossim/components/Buzzer/BuzzerWidget.jsx
+++ b/packages/@logossim/components/Buzzer/BuzzerWidget.jsx
@@ -55,7 +55,7 @@ const BuzzerWidget = props => {
 
   return (
     <Shape selected={selected} isActive={model.isActive()}>
-      <PositionedPort name="in" model={model} />
+      <PositionedPort name="in" />
     </Shape>
   );
 };

--- a/packages/@logossim/components/Buzzer/BuzzerWidget.jsx
+++ b/packages/@logossim/components/Buzzer/BuzzerWidget.jsx
@@ -55,12 +55,7 @@ export const BuzzerWidget = props => {
 
   return (
     <Shape selected={selected} isActive={model.isActive()}>
-      <PositionedPort
-        name="in"
-        model={model}
-        port={model.getPort('in')}
-        engine={engine}
-      />
+      <PositionedPort name="in" model={model} engine={engine} />
     </Shape>
   );
 };

--- a/packages/@logossim/components/Buzzer/__tests__/BuzzerModel.test.js
+++ b/packages/@logossim/components/Buzzer/__tests__/BuzzerModel.test.js
@@ -2,6 +2,13 @@ import BuzzerModel from '../BuzzerModel';
 
 const { addPort } = global;
 
+beforeEach(() => {
+  const getPortSpy = jest.spyOn(BuzzerModel.prototype, 'getPort');
+  getPortSpy.mockImplementation(() => ({
+    getValue: () => [0],
+  }));
+});
+
 it('should add ports on initialization', () => {
   const spy = jest.spyOn(BuzzerModel.prototype, 'addInputPort');
   spy.mockImplementation(addPort);

--- a/packages/@logossim/components/Buzzer/__tests__/BuzzerModel.test.js
+++ b/packages/@logossim/components/Buzzer/__tests__/BuzzerModel.test.js
@@ -2,63 +2,65 @@ import BuzzerModel from '../BuzzerModel';
 
 const { addPort } = global;
 
-beforeEach(() => {
-  const getPortSpy = jest.spyOn(BuzzerModel.prototype, 'getPort');
-  getPortSpy.mockImplementation(() => ({
-    getValue: () => [0],
-  }));
-});
-
-it('should add ports on initialization', () => {
-  const spy = jest.spyOn(BuzzerModel.prototype, 'addInputPort');
-  spy.mockImplementation(addPort);
-
-  new BuzzerModel();
-
-  expect(spy).toHaveBeenCalledWith('in');
-});
-
-it('should instantiate audio on simulation start with correct parameters', () => {
-  const model = new BuzzerModel({
-    FREQUENCY_HZ: 1000,
-    WAVEFORM: 'SAWTOOTH',
+describe('BuzzerModel', () => {
+  beforeEach(() => {
+    const getPortSpy = jest.spyOn(BuzzerModel.prototype, 'getPort');
+    getPortSpy.mockImplementation(() => ({
+      getValue: () => [0],
+    }));
   });
-  const spy = jest.spyOn(model, 'createAudio');
 
-  model.onSimulationStart();
+  it('should add ports on initialization', () => {
+    const spy = jest.spyOn(BuzzerModel.prototype, 'addInputPort');
+    spy.mockImplementation(addPort);
 
-  expect(spy).toHaveBeenCalledWith(1000, 'SAWTOOTH');
-});
+    new BuzzerModel();
 
-it('should pause the audio on simulation pause', () => {
-  const model = new BuzzerModel();
-  model.audio = { pause: () => {} };
+    expect(spy).toHaveBeenCalledWith('in');
+  });
 
-  const spy = jest.spyOn(model.audio, 'pause');
+  it('should instantiate audio on simulation start with correct parameters', () => {
+    const model = new BuzzerModel({
+      FREQUENCY_HZ: 1000,
+      WAVEFORM: 'SAWTOOTH',
+    });
+    const spy = jest.spyOn(model, 'createAudio');
 
-  model.onSimulationPause();
+    model.onSimulationStart();
 
-  expect(spy).toHaveBeenCalled();
-});
+    expect(spy).toHaveBeenCalledWith(1000, 'SAWTOOTH');
+  });
 
-it('should play the audio when input is high', () => {
-  const model = new BuzzerModel();
-  model.audio = { play: () => {} };
+  it('should pause the audio on simulation pause', () => {
+    const model = new BuzzerModel();
+    model.audio = { pause: () => {} };
 
-  const spy = jest.spyOn(model.audio, 'play');
+    const spy = jest.spyOn(model.audio, 'pause');
 
-  model.step({ in: 1 });
+    model.onSimulationPause();
 
-  expect(spy).toHaveBeenCalled();
-});
+    expect(spy).toHaveBeenCalled();
+  });
 
-it('should pause the audio when input is low', () => {
-  const model = new BuzzerModel();
-  model.audio = { pause: () => {} };
+  it('should play the audio when input is high', () => {
+    const model = new BuzzerModel();
+    model.audio = { play: () => {} };
 
-  const spy = jest.spyOn(model.audio, 'pause');
+    const spy = jest.spyOn(model.audio, 'play');
 
-  model.step({ in: 0 });
+    model.step({ in: 1 });
 
-  expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should pause the audio when input is low', () => {
+    const model = new BuzzerModel();
+    model.audio = { pause: () => {} };
+
+    const spy = jest.spyOn(model.audio, 'pause');
+
+    model.step({ in: 0 });
+
+    expect(spy).toHaveBeenCalled();
+  });
 });

--- a/packages/@logossim/components/Buzzer/__tests__/BuzzerModel.test.js
+++ b/packages/@logossim/components/Buzzer/__tests__/BuzzerModel.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import BuzzerModel from '../BuzzerModel';
 
 const { addPort } = global;

--- a/packages/@logossim/components/Buzzer/__tests__/BuzzerWidget.test.jsx
+++ b/packages/@logossim/components/Buzzer/__tests__/BuzzerWidget.test.jsx
@@ -1,18 +1,14 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render } from '../../testUtils';
 
 import BuzzerModel from '../BuzzerModel';
 import BuzzerWidget from '../BuzzerWidget';
 
-const { engine } = global;
-
 it('should have 1 input port', () => {
   const model = new BuzzerModel();
 
-  const { container } = render(
-    <BuzzerWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<BuzzerWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name=in]');
   expect(ports).toHaveLength(1);
@@ -23,9 +19,7 @@ it('should display a shadow when active', () => {
   const spy = jest.spyOn(model, 'isActive');
   spy.mockImplementation(() => true);
 
-  const { getByTestId } = render(
-    <BuzzerWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<BuzzerWidget model={model} />);
   const body = getByTestId('body');
 
   expect(body).toHaveStyle('box-shadow: 0 0 15px black');
@@ -36,9 +30,7 @@ it('should not display a shadow when inactive', () => {
   const spy = jest.spyOn(model, 'isActive');
   spy.mockImplementation(() => false);
 
-  const { getByTestId } = render(
-    <BuzzerWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<BuzzerWidget model={model} />);
   const body = getByTestId('body');
 
   expect(body).toHaveStyle('box-shadow: 0 0 0px black');

--- a/packages/@logossim/components/Buzzer/__tests__/BuzzerWidget.test.jsx
+++ b/packages/@logossim/components/Buzzer/__tests__/BuzzerWidget.test.jsx
@@ -1,37 +1,38 @@
 import React from 'react';
 
 import { render } from '../../testUtils';
-
 import BuzzerModel from '../BuzzerModel';
 import BuzzerWidget from '../BuzzerWidget';
 
-it('should have 1 input port', () => {
-  const model = new BuzzerModel();
+describe('BuzzerWidget', () => {
+  it('should have 1 input port', () => {
+    const model = new BuzzerModel();
 
-  const { container } = render(<BuzzerWidget model={model} />);
+    const { container } = render(<BuzzerWidget model={model} />);
 
-  const ports = container.querySelectorAll('[data-name=in]');
-  expect(ports).toHaveLength(1);
-});
+    const ports = container.querySelectorAll('[data-name=in]');
+    expect(ports).toHaveLength(1);
+  });
 
-it('should display a shadow when active', () => {
-  const model = new BuzzerModel();
-  const spy = jest.spyOn(model, 'isActive');
-  spy.mockImplementation(() => true);
+  it('should display a shadow when active', () => {
+    const model = new BuzzerModel();
+    const spy = jest.spyOn(model, 'isActive');
+    spy.mockImplementation(() => true);
 
-  const { getByTestId } = render(<BuzzerWidget model={model} />);
-  const body = getByTestId('body');
+    const { getByTestId } = render(<BuzzerWidget model={model} />);
+    const body = getByTestId('body');
 
-  expect(body).toHaveStyle('box-shadow: 0 0 15px black');
-});
+    expect(body).toHaveStyle('box-shadow: 0 0 15px black');
+  });
 
-it('should not display a shadow when inactive', () => {
-  const model = new BuzzerModel();
-  const spy = jest.spyOn(model, 'isActive');
-  spy.mockImplementation(() => false);
+  it('should not display a shadow when inactive', () => {
+    const model = new BuzzerModel();
+    const spy = jest.spyOn(model, 'isActive');
+    spy.mockImplementation(() => false);
 
-  const { getByTestId } = render(<BuzzerWidget model={model} />);
-  const body = getByTestId('body');
+    const { getByTestId } = render(<BuzzerWidget model={model} />);
+    const body = getByTestId('body');
 
-  expect(body).toHaveStyle('box-shadow: 0 0 0px black');
+    expect(body).toHaveStyle('box-shadow: 0 0 0px black');
+  });
 });

--- a/packages/@logossim/components/Clock/ClockWidget.jsx
+++ b/packages/@logossim/components/Clock/ClockWidget.jsx
@@ -72,7 +72,7 @@ const ClockWidget = props => {
 
   return (
     <Shape selected={selected}>
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="out" />
       <Decoration
         isActive={model.isActive()}
         color={out.getColor()}

--- a/packages/@logossim/components/Clock/ClockWidget.jsx
+++ b/packages/@logossim/components/Clock/ClockWidget.jsx
@@ -72,12 +72,7 @@ const ClockWidget = props => {
 
   return (
     <Shape selected={selected}>
-      <PositionedPort
-        name="out"
-        model={model}
-        port={out}
-        engine={engine}
-      />
+      <PositionedPort name="out" model={model} engine={engine} />
       <Decoration
         isActive={model.isActive()}
         color={out.getColor()}

--- a/packages/@logossim/components/Clock/ClockWidget.jsx
+++ b/packages/@logossim/components/Clock/ClockWidget.jsx
@@ -62,7 +62,7 @@ export const Decoration = ({
 );
 
 const ClockWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
     periodMs,
@@ -72,7 +72,7 @@ const ClockWidget = props => {
 
   return (
     <Shape selected={selected}>
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} />
       <Decoration
         isActive={model.isActive()}
         color={out.getColor()}

--- a/packages/@logossim/components/Clock/__tests__/ClockModel.test.js
+++ b/packages/@logossim/components/Clock/__tests__/ClockModel.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import ClockModel from '../ClockModel';
 
 const { addPort } = global;

--- a/packages/@logossim/components/Clock/__tests__/ClockModel.test.js
+++ b/packages/@logossim/components/Clock/__tests__/ClockModel.test.js
@@ -2,112 +2,114 @@ import ClockModel from '../ClockModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const spy = jest.spyOn(ClockModel.prototype, 'addOutputPort');
-  spy.mockImplementation(addPort);
+describe('ClockModel', () => {
+  it('should add ports on initialization', () => {
+    const spy = jest.spyOn(ClockModel.prototype, 'addOutputPort');
+    spy.mockImplementation(addPort);
 
-  new ClockModel();
+    new ClockModel();
 
-  expect(spy).toHaveBeenCalledWith('out');
-});
-
-it('should emit on simulation start', () => {
-  const model = new ClockModel();
-  const spy = jest.spyOn(model, 'emit');
-  model.onSimulationStart();
-
-  expect(spy).toHaveBeenCalledWith({ out: 0 });
-});
-
-it('should generate the correct signal', () => {
-  jest.useFakeTimers();
-
-  const model = new ClockModel({
-    FREQUENCY_HZ: 1,
-    HIGH_DURATION: 1,
-    LOW_DURATION: 1,
+    expect(spy).toHaveBeenCalledWith('out');
   });
-  const spy = jest.spyOn(model, 'emit');
 
-  model.onSimulationStart();
+  it('should emit on simulation start', () => {
+    const model = new ClockModel();
+    const spy = jest.spyOn(model, 'emit');
+    model.onSimulationStart();
 
-  expect(spy).toHaveBeenNthCalledWith(1, { out: 0 });
-  jest.advanceTimersByTime(500);
-
-  expect(spy).toHaveBeenNthCalledWith(2, { out: 1 });
-  jest.advanceTimersByTime(500);
-
-  expect(spy).toHaveBeenNthCalledWith(3, { out: 0 });
-});
-
-it('should be able to generate with custom high duration', () => {
-  jest.useFakeTimers();
-
-  const model = new ClockModel({
-    FREQUENCY_HZ: 1,
-    HIGH_DURATION: 2,
-    LOW_DURATION: 1,
+    expect(spy).toHaveBeenCalledWith({ out: 0 });
   });
-  const spy = jest.spyOn(model, 'emit');
 
-  model.onSimulationStart();
+  it('should generate the correct signal', () => {
+    jest.useFakeTimers();
 
-  expect(spy).toHaveBeenNthCalledWith(1, { out: 0 });
-  jest.advanceTimersByTime(500);
+    const model = new ClockModel({
+      FREQUENCY_HZ: 1,
+      HIGH_DURATION: 1,
+      LOW_DURATION: 1,
+    });
+    const spy = jest.spyOn(model, 'emit');
 
-  expect(spy).toHaveBeenNthCalledWith(2, { out: 1 });
-  jest.advanceTimersByTime(1000);
+    model.onSimulationStart();
 
-  expect(spy).toHaveBeenNthCalledWith(3, { out: 0 });
-});
+    expect(spy).toHaveBeenNthCalledWith(1, { out: 0 });
+    jest.advanceTimersByTime(500);
 
-it('should be able to generate with custom low duration', () => {
-  jest.useFakeTimers();
+    expect(spy).toHaveBeenNthCalledWith(2, { out: 1 });
+    jest.advanceTimersByTime(500);
 
-  const model = new ClockModel({
-    FREQUENCY_HZ: 1,
-    HIGH_DURATION: 1,
-    LOW_DURATION: 2,
+    expect(spy).toHaveBeenNthCalledWith(3, { out: 0 });
   });
-  const spy = jest.spyOn(model, 'emit');
 
-  model.onSimulationStart();
+  it('should be able to generate with custom high duration', () => {
+    jest.useFakeTimers();
 
-  expect(spy).toHaveBeenNthCalledWith(1, { out: 0 });
-  jest.advanceTimersByTime(1000);
+    const model = new ClockModel({
+      FREQUENCY_HZ: 1,
+      HIGH_DURATION: 2,
+      LOW_DURATION: 1,
+    });
+    const spy = jest.spyOn(model, 'emit');
 
-  expect(spy).toHaveBeenNthCalledWith(2, { out: 1 });
-  jest.advanceTimersByTime(500);
+    model.onSimulationStart();
 
-  expect(spy).toHaveBeenNthCalledWith(3, { out: 0 });
-});
+    expect(spy).toHaveBeenNthCalledWith(1, { out: 0 });
+    jest.advanceTimersByTime(500);
 
-it('should pause the signal generation upon simulation pause', () => {
-  jest.useFakeTimers();
+    expect(spy).toHaveBeenNthCalledWith(2, { out: 1 });
+    jest.advanceTimersByTime(1000);
 
-  const model = new ClockModel({
-    FREQUENCY_HZ: 1,
-    HIGH_DURATION: 1,
-    LOW_DURATION: 1,
+    expect(spy).toHaveBeenNthCalledWith(3, { out: 0 });
   });
-  const spy = jest.spyOn(model, 'emit');
 
-  model.onSimulationStart();
+  it('should be able to generate with custom low duration', () => {
+    jest.useFakeTimers();
 
-  expect(spy).toHaveBeenNthCalledWith(1, { out: 0 });
-  jest.advanceTimersByTime(500);
+    const model = new ClockModel({
+      FREQUENCY_HZ: 1,
+      HIGH_DURATION: 1,
+      LOW_DURATION: 2,
+    });
+    const spy = jest.spyOn(model, 'emit');
 
-  expect(spy).toHaveBeenNthCalledWith(2, { out: 1 });
+    model.onSimulationStart();
 
-  model.onSimulationPause();
-  jest.advanceTimersByTime(5000);
+    expect(spy).toHaveBeenNthCalledWith(1, { out: 0 });
+    jest.advanceTimersByTime(1000);
 
-  expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenNthCalledWith(2, { out: 1 });
+    jest.advanceTimersByTime(500);
 
-  model.onSimulationStart();
+    expect(spy).toHaveBeenNthCalledWith(3, { out: 0 });
+  });
 
-  expect(spy).toHaveBeenNthCalledWith(3, { out: 1 });
-  jest.advanceTimersByTime(500);
+  it('should pause the signal generation upon simulation pause', () => {
+    jest.useFakeTimers();
 
-  expect(spy).toHaveBeenNthCalledWith(4, { out: 0 });
+    const model = new ClockModel({
+      FREQUENCY_HZ: 1,
+      HIGH_DURATION: 1,
+      LOW_DURATION: 1,
+    });
+    const spy = jest.spyOn(model, 'emit');
+
+    model.onSimulationStart();
+
+    expect(spy).toHaveBeenNthCalledWith(1, { out: 0 });
+    jest.advanceTimersByTime(500);
+
+    expect(spy).toHaveBeenNthCalledWith(2, { out: 1 });
+
+    model.onSimulationPause();
+    jest.advanceTimersByTime(5000);
+
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    model.onSimulationStart();
+
+    expect(spy).toHaveBeenNthCalledWith(3, { out: 1 });
+    jest.advanceTimersByTime(500);
+
+    expect(spy).toHaveBeenNthCalledWith(4, { out: 0 });
+  });
 });

--- a/packages/@logossim/components/Clock/__tests__/ClockWidget.test.jsx
+++ b/packages/@logossim/components/Clock/__tests__/ClockWidget.test.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import ClockModel from '../ClockModel';
 import ClockWidget from '../ClockWidget';
-
-const { engine } = global;
 
 it('should have 1 output port', () => {
   const model = new ClockModel('Clock', {
@@ -14,9 +11,7 @@ it('should have 1 output port', () => {
     LOW_DURATION: 1,
   });
 
-  const { container } = render(
-    <ClockWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<ClockWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name=out]');
   expect(ports).toHaveLength(1);
@@ -30,9 +25,7 @@ it('should display off value', () => {
   });
   model.getPort('out').setValue([0]);
 
-  const { getByTestId } = render(
-    <ClockWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<ClockWidget model={model} />);
   const decoration = getByTestId('decoration');
 
   expect(decoration).toHaveStyle('transform: rotateX(180deg)');
@@ -46,9 +39,7 @@ it('should display on value', () => {
   });
   model.getPort('out').setValue([1]);
 
-  const { getByTestId } = render(
-    <ClockWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<ClockWidget model={model} />);
   const decoration = getByTestId('decoration');
 
   expect(decoration).toHaveStyle('transform: none');

--- a/packages/@logossim/components/Clock/__tests__/ClockWidget.test.jsx
+++ b/packages/@logossim/components/Clock/__tests__/ClockWidget.test.jsx
@@ -4,43 +4,45 @@ import { render } from '../../testUtils';
 import ClockModel from '../ClockModel';
 import ClockWidget from '../ClockWidget';
 
-it('should have 1 output port', () => {
-  const model = new ClockModel('Clock', {
-    FREQUENCY_HZ: 1,
-    HIGH_DURATION: 1,
-    LOW_DURATION: 1,
+describe('ClockWidget', () => {
+  it('should have 1 output port', () => {
+    const model = new ClockModel('Clock', {
+      FREQUENCY_HZ: 1,
+      HIGH_DURATION: 1,
+      LOW_DURATION: 1,
+    });
+
+    const { container } = render(<ClockWidget model={model} />);
+
+    const ports = container.querySelectorAll('[data-name=out]');
+    expect(ports).toHaveLength(1);
   });
 
-  const { container } = render(<ClockWidget model={model} />);
+  it('should display off value', () => {
+    const model = new ClockModel('Clock', {
+      FREQUENCY_HZ: 1,
+      HIGH_DURATION: 1,
+      LOW_DURATION: 1,
+    });
+    model.getPort('out').setValue([0]);
 
-  const ports = container.querySelectorAll('[data-name=out]');
-  expect(ports).toHaveLength(1);
-});
+    const { getByTestId } = render(<ClockWidget model={model} />);
+    const decoration = getByTestId('decoration');
 
-it('should display off value', () => {
-  const model = new ClockModel('Clock', {
-    FREQUENCY_HZ: 1,
-    HIGH_DURATION: 1,
-    LOW_DURATION: 1,
+    expect(decoration).toHaveStyle('transform: rotateX(180deg)');
   });
-  model.getPort('out').setValue([0]);
 
-  const { getByTestId } = render(<ClockWidget model={model} />);
-  const decoration = getByTestId('decoration');
+  it('should display on value', () => {
+    const model = new ClockModel('Clock', {
+      FREQUENCY_HZ: 1,
+      HIGH_DURATION: 1,
+      LOW_DURATION: 1,
+    });
+    model.getPort('out').setValue([1]);
 
-  expect(decoration).toHaveStyle('transform: rotateX(180deg)');
-});
+    const { getByTestId } = render(<ClockWidget model={model} />);
+    const decoration = getByTestId('decoration');
 
-it('should display on value', () => {
-  const model = new ClockModel('Clock', {
-    FREQUENCY_HZ: 1,
-    HIGH_DURATION: 1,
-    LOW_DURATION: 1,
+    expect(decoration).toHaveStyle('transform: none');
   });
-  model.getPort('out').setValue([1]);
-
-  const { getByTestId } = render(<ClockWidget model={model} />);
-  const decoration = getByTestId('decoration');
-
-  expect(decoration).toHaveStyle('transform: none');
 });

--- a/packages/@logossim/components/ControlledBuffer/ControlledBufferModel.js
+++ b/packages/@logossim/components/ControlledBuffer/ControlledBufferModel.js
@@ -5,8 +5,8 @@ export default class ControlledBufferModel extends BaseModel {
     const DATA_BITS = Number(configurations.DATA_BITS);
 
     this.addInputPort('control');
-    this.addInputPort('in', DATA_BITS);
-    this.addOutputPort('out', DATA_BITS);
+    this.addInputPort('in', { bits: DATA_BITS });
+    this.addOutputPort('out', { bits: DATA_BITS });
   }
 
   step(input) {

--- a/packages/@logossim/components/ControlledBuffer/ControlledBufferWidget.jsx
+++ b/packages/@logossim/components/ControlledBuffer/ControlledBufferWidget.jsx
@@ -60,9 +60,9 @@ const ControlledBufferWidget = props => {
 
   return (
     <Wrapper selected={selected}>
-      <PositionedPort name="control" model={model} />
-      <PositionedPort name="in" model={model} />
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="control" />
+      <PositionedPort name="in" />
+      <PositionedPort name="out" />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/ControlledBuffer/ControlledBufferWidget.jsx
+++ b/packages/@logossim/components/ControlledBuffer/ControlledBufferWidget.jsx
@@ -60,24 +60,9 @@ const ControlledBufferWidget = props => {
 
   return (
     <Wrapper selected={selected}>
-      <PositionedPort
-        name="control"
-        model={model}
-        port={model.getPort('control')}
-        engine={engine}
-      />
-      <PositionedPort
-        name="in"
-        model={model}
-        port={model.getPort('in')}
-        engine={engine}
-      />
-      <PositionedPort
-        name="out"
-        model={model}
-        port={model.getPort('out')}
-        engine={engine}
-      />
+      <PositionedPort name="control" model={model} engine={engine} />
+      <PositionedPort name="in" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} engine={engine} />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/ControlledBuffer/ControlledBufferWidget.jsx
+++ b/packages/@logossim/components/ControlledBuffer/ControlledBufferWidget.jsx
@@ -53,16 +53,16 @@ export const Shape = ({ size = 30 }) => (
 );
 
 const ControlledBufferWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
   } = model;
 
   return (
     <Wrapper selected={selected}>
-      <PositionedPort name="control" model={model} engine={engine} />
-      <PositionedPort name="in" model={model} engine={engine} />
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="control" model={model} />
+      <PositionedPort name="in" model={model} />
+      <PositionedPort name="out" model={model} />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/ControlledBuffer/__tests__/ControlledBufferModel.test.js
+++ b/packages/@logossim/components/ControlledBuffer/__tests__/ControlledBufferModel.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import ControlledBufferModel from '../ControlledBufferModel';
 
 const { addPort } = global;

--- a/packages/@logossim/components/ControlledBuffer/__tests__/ControlledBufferModel.test.js
+++ b/packages/@logossim/components/ControlledBuffer/__tests__/ControlledBufferModel.test.js
@@ -2,63 +2,65 @@ import ControlledBufferModel from '../ControlledBufferModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const addInputSpy = jest.spyOn(
-    ControlledBufferModel.prototype,
-    'addInputPort',
-  );
-  addInputSpy.mockImplementation(addPort);
+describe('ControlledBufferModel', () => {
+  it('should add ports on initialization', () => {
+    const addInputSpy = jest.spyOn(
+      ControlledBufferModel.prototype,
+      'addInputPort',
+    );
+    addInputSpy.mockImplementation(addPort);
 
-  const addOutputSpy = jest.spyOn(
-    ControlledBufferModel.prototype,
-    'addOutputPort',
-  );
-  addOutputSpy.mockImplementation(addPort);
+    const addOutputSpy = jest.spyOn(
+      ControlledBufferModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  new ControlledBufferModel({
-    DATA_BITS: 4,
+    new ControlledBufferModel({
+      DATA_BITS: 4,
+    });
+
+    expect(addInputSpy).toHaveBeenCalledWith('control');
+    expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 4 });
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
   });
 
-  expect(addInputSpy).toHaveBeenCalledWith('control');
-  expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 4 });
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
-});
+  it('should output floating values when control is not set', () => {
+    const model = new ControlledBufferModel({
+      DATA_BITS: 4,
+    });
 
-it('should output floating values when control is not set', () => {
-  const model = new ControlledBufferModel({
-    DATA_BITS: 4,
+    expect(
+      model.stepFloating({
+        control: [0],
+        in: [0, 1, 'x', 'e'],
+      }),
+    ).toEqual({ out: 'x' });
   });
 
-  expect(
-    model.stepFloating({
-      control: [0],
-      in: [0, 1, 'x', 'e'],
-    }),
-  ).toEqual({ out: 'x' });
-});
+  it('should output values unmodified when control is set', () => {
+    const model = new ControlledBufferModel({
+      DATA_BITS: 4,
+    });
 
-it('should output values unmodified when control is set', () => {
-  const model = new ControlledBufferModel({
-    DATA_BITS: 4,
+    expect(
+      model.stepFloating({
+        control: [1],
+        in: [0, 1, 'x', 'e'],
+      }),
+    ).toEqual({ out: [0, 1, 'x', 'e'] });
   });
 
-  expect(
-    model.stepFloating({
-      control: [1],
-      in: [0, 1, 'x', 'e'],
-    }),
-  ).toEqual({ out: [0, 1, 'x', 'e'] });
-});
+  it('should output error when control is floating', () => {
+    const model = new ControlledBufferModel({
+      DATA_BITS: 4,
+    });
 
-it('should output error when control is floating', () => {
-  const model = new ControlledBufferModel({
-    DATA_BITS: 4,
+    expect(
+      model.stepFloating({
+        control: ['x'],
+        in: [0, 1, 'x', 'e'],
+      }),
+    ).toEqual({ out: 'e' });
   });
-
-  expect(
-    model.stepFloating({
-      control: ['x'],
-      in: [0, 1, 'x', 'e'],
-    }),
-  ).toEqual({ out: 'e' });
 });

--- a/packages/@logossim/components/ControlledBuffer/__tests__/ControlledBufferModel.test.js
+++ b/packages/@logossim/components/ControlledBuffer/__tests__/ControlledBufferModel.test.js
@@ -21,8 +21,8 @@ it('should add ports on initialization', () => {
   });
 
   expect(addInputSpy).toHaveBeenCalledWith('control');
-  expect(addInputSpy).toHaveBeenCalledWith('in', 4);
-  expect(addOutputSpy).toHaveBeenCalledWith('out', 4);
+  expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 4 });
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
 });
 
 it('should output floating values when control is not set', () => {

--- a/packages/@logossim/components/ControlledBuffer/__tests__/ControlledBufferWidget.test.jsx
+++ b/packages/@logossim/components/ControlledBuffer/__tests__/ControlledBufferWidget.test.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render } from '../../testUtils';
 
 import ControlledBufferModel from '../ControlledBufferModel';
 import ControlledBufferWidget from '../ControlledBufferWidget';
-
-const { engine } = global;
 
 it('should have 2 input and 1 output port', () => {
   const model = new ControlledBufferModel({
@@ -13,7 +11,7 @@ it('should have 2 input and 1 output port', () => {
   });
 
   const { container } = render(
-    <ControlledBufferWidget model={model} engine={engine} />,
+    <ControlledBufferWidget model={model} />,
   );
 
   const control = container.querySelector('[data-name=control]');

--- a/packages/@logossim/components/ControlledBuffer/__tests__/ControlledBufferWidget.test.jsx
+++ b/packages/@logossim/components/ControlledBuffer/__tests__/ControlledBufferWidget.test.jsx
@@ -1,25 +1,26 @@
 import React from 'react';
 
 import { render } from '../../testUtils';
-
 import ControlledBufferModel from '../ControlledBufferModel';
 import ControlledBufferWidget from '../ControlledBufferWidget';
 
-it('should have 2 input and 1 output port', () => {
-  const model = new ControlledBufferModel({
-    DATA_BITS: 1,
+describe('ControlledBufferWidget', () => {
+  it('should have 2 input and 1 output port', () => {
+    const model = new ControlledBufferModel({
+      DATA_BITS: 1,
+    });
+
+    const { container } = render(
+      <ControlledBufferWidget model={model} />,
+    );
+
+    const control = container.querySelector('[data-name=control]');
+    expect(control).toBeTruthy();
+
+    const input = container.querySelector('[data-name=in]');
+    expect(input).toBeTruthy();
+
+    const output = container.querySelector('[data-name=out]');
+    expect(output).toBeTruthy();
   });
-
-  const { container } = render(
-    <ControlledBufferWidget model={model} />,
-  );
-
-  const control = container.querySelector('[data-name=control]');
-  expect(control).toBeTruthy();
-
-  const input = container.querySelector('[data-name=in]');
-  expect(input).toBeTruthy();
-
-  const output = container.querySelector('[data-name=out]');
-  expect(output).toBeTruthy();
 });

--- a/packages/@logossim/components/ControlledInverter/ControlledInverterModel.js
+++ b/packages/@logossim/components/ControlledInverter/ControlledInverterModel.js
@@ -5,8 +5,8 @@ export default class ControlledInverterModel extends BaseModel {
     const DATA_BITS = Number(configurations.DATA_BITS);
 
     this.addInputPort('control');
-    this.addInputPort('in', DATA_BITS);
-    this.addOutputPort('out', DATA_BITS);
+    this.addInputPort('in', { bits: DATA_BITS });
+    this.addOutputPort('out', { bits: DATA_BITS });
   }
 
   step(input) {

--- a/packages/@logossim/components/ControlledInverter/ControlledInverterWidget.jsx
+++ b/packages/@logossim/components/ControlledInverter/ControlledInverterWidget.jsx
@@ -61,24 +61,9 @@ const ControlledInverterWidget = props => {
 
   return (
     <Wrapper selected={selected}>
-      <PositionedPort
-        name="control"
-        model={model}
-        port={model.getPort('control')}
-        engine={engine}
-      />
-      <PositionedPort
-        name="in"
-        model={model}
-        port={model.getPort('in')}
-        engine={engine}
-      />
-      <PositionedPort
-        name="out"
-        model={model}
-        port={model.getPort('out')}
-        engine={engine}
-      />
+      <PositionedPort name="control" model={model} engine={engine} />
+      <PositionedPort name="in" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} engine={engine} />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/ControlledInverter/ControlledInverterWidget.jsx
+++ b/packages/@logossim/components/ControlledInverter/ControlledInverterWidget.jsx
@@ -54,16 +54,16 @@ export const Shape = ({ size = 30 }) => (
 );
 
 const ControlledInverterWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
   } = model;
 
   return (
     <Wrapper selected={selected}>
-      <PositionedPort name="control" model={model} engine={engine} />
-      <PositionedPort name="in" model={model} engine={engine} />
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="control" model={model} />
+      <PositionedPort name="in" model={model} />
+      <PositionedPort name="out" model={model} />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/ControlledInverter/ControlledInverterWidget.jsx
+++ b/packages/@logossim/components/ControlledInverter/ControlledInverterWidget.jsx
@@ -61,9 +61,9 @@ const ControlledInverterWidget = props => {
 
   return (
     <Wrapper selected={selected}>
-      <PositionedPort name="control" model={model} />
-      <PositionedPort name="in" model={model} />
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="control" />
+      <PositionedPort name="in" />
+      <PositionedPort name="out" />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/ControlledInverter/__tests__/ControlledInverterModel.test.js
+++ b/packages/@logossim/components/ControlledInverter/__tests__/ControlledInverterModel.test.js
@@ -2,63 +2,65 @@ import ControlledInverterModel from '../ControlledInverterModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const addInputSpy = jest.spyOn(
-    ControlledInverterModel.prototype,
-    'addInputPort',
-  );
-  addInputSpy.mockImplementation(addPort);
+describe('ControlledInverterModel', () => {
+  it('should add ports on initialization', () => {
+    const addInputSpy = jest.spyOn(
+      ControlledInverterModel.prototype,
+      'addInputPort',
+    );
+    addInputSpy.mockImplementation(addPort);
 
-  const addOutputSpy = jest.spyOn(
-    ControlledInverterModel.prototype,
-    'addOutputPort',
-  );
-  addOutputSpy.mockImplementation(addPort);
+    const addOutputSpy = jest.spyOn(
+      ControlledInverterModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  new ControlledInverterModel({
-    DATA_BITS: 4,
+    new ControlledInverterModel({
+      DATA_BITS: 4,
+    });
+
+    expect(addInputSpy).toHaveBeenCalledWith('control');
+    expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 4 });
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
   });
 
-  expect(addInputSpy).toHaveBeenCalledWith('control');
-  expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 4 });
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
-});
+  it('should output floating values when control is not set', () => {
+    const model = new ControlledInverterModel({
+      DATA_BITS: 4,
+    });
 
-it('should output floating values when control is not set', () => {
-  const model = new ControlledInverterModel({
-    DATA_BITS: 4,
+    expect(
+      model.stepFloating({
+        control: [0],
+        in: [0, 1, 'x', 'e'],
+      }),
+    ).toEqual({ out: 'x' });
   });
 
-  expect(
-    model.stepFloating({
-      control: [0],
-      in: [0, 1, 'x', 'e'],
-    }),
-  ).toEqual({ out: 'x' });
-});
+  it('should output values negated values when control is set', () => {
+    const model = new ControlledInverterModel({
+      DATA_BITS: 4,
+    });
 
-it('should output values negated values when control is set', () => {
-  const model = new ControlledInverterModel({
-    DATA_BITS: 4,
+    expect(
+      model.stepFloating({
+        control: [1],
+        in: [0, 1, 'x', 'e'],
+      }),
+    ).toEqual({ out: [1, 0, 'e', 'e'] });
   });
 
-  expect(
-    model.stepFloating({
-      control: [1],
-      in: [0, 1, 'x', 'e'],
-    }),
-  ).toEqual({ out: [1, 0, 'e', 'e'] });
-});
+  it('should output error when control is floating', () => {
+    const model = new ControlledInverterModel({
+      DATA_BITS: 4,
+    });
 
-it('should output error when control is floating', () => {
-  const model = new ControlledInverterModel({
-    DATA_BITS: 4,
+    expect(
+      model.stepFloating({
+        control: ['x'],
+        in: [0, 1, 'x', 'e'],
+      }),
+    ).toEqual({ out: 'e' });
   });
-
-  expect(
-    model.stepFloating({
-      control: ['x'],
-      in: [0, 1, 'x', 'e'],
-    }),
-  ).toEqual({ out: 'e' });
 });

--- a/packages/@logossim/components/ControlledInverter/__tests__/ControlledInverterModel.test.js
+++ b/packages/@logossim/components/ControlledInverter/__tests__/ControlledInverterModel.test.js
@@ -21,8 +21,8 @@ it('should add ports on initialization', () => {
   });
 
   expect(addInputSpy).toHaveBeenCalledWith('control');
-  expect(addInputSpy).toHaveBeenCalledWith('in', 4);
-  expect(addOutputSpy).toHaveBeenCalledWith('out', 4);
+  expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 4 });
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
 });
 
 it('should output floating values when control is not set', () => {

--- a/packages/@logossim/components/ControlledInverter/__tests__/ControlledInverterModel.test.js
+++ b/packages/@logossim/components/ControlledInverter/__tests__/ControlledInverterModel.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import ControlledInverterModel from '../ControlledInverterModel';
 
 const { addPort } = global;

--- a/packages/@logossim/components/ControlledInverter/__tests__/ControlledInverterWidget.test.jsx
+++ b/packages/@logossim/components/ControlledInverter/__tests__/ControlledInverterWidget.test.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import ControlledInverterModel from '../ControlledInverterModel';
 import ControlledInverterWidget from '../ControlledInverterWidget';
-
-const { engine } = global;
 
 it('should have 2 input and 1 output port', () => {
   const model = new ControlledInverterModel({
@@ -13,7 +10,7 @@ it('should have 2 input and 1 output port', () => {
   });
 
   const { container } = render(
-    <ControlledInverterWidget model={model} engine={engine} />,
+    <ControlledInverterWidget model={model} />,
   );
 
   const control = container.querySelector('[data-name=control]');

--- a/packages/@logossim/components/ControlledInverter/__tests__/ControlledInverterWidget.test.jsx
+++ b/packages/@logossim/components/ControlledInverter/__tests__/ControlledInverterWidget.test.jsx
@@ -4,21 +4,23 @@ import { render } from '../../testUtils';
 import ControlledInverterModel from '../ControlledInverterModel';
 import ControlledInverterWidget from '../ControlledInverterWidget';
 
-it('should have 2 input and 1 output port', () => {
-  const model = new ControlledInverterModel({
-    DATA_BITS: 1,
+describe('ControlledInverterWidget', () => {
+  it('should have 2 input and 1 output port', () => {
+    const model = new ControlledInverterModel({
+      DATA_BITS: 1,
+    });
+
+    const { container } = render(
+      <ControlledInverterWidget model={model} />,
+    );
+
+    const control = container.querySelector('[data-name=control]');
+    expect(control).toBeTruthy();
+
+    const input = container.querySelector('[data-name=in]');
+    expect(input).toBeTruthy();
+
+    const output = container.querySelector('[data-name=out]');
+    expect(output).toBeTruthy();
   });
-
-  const { container } = render(
-    <ControlledInverterWidget model={model} />,
-  );
-
-  const control = container.querySelector('[data-name=control]');
-  expect(control).toBeTruthy();
-
-  const input = container.querySelector('[data-name=in]');
-  expect(input).toBeTruthy();
-
-  const output = container.querySelector('[data-name=out]');
-  expect(output).toBeTruthy();
 });

--- a/packages/@logossim/components/Counter/CounterIcon.jsx
+++ b/packages/@logossim/components/Counter/CounterIcon.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import { Wrapper } from './CounterWidget';
+
+const CounterIcon = () => <Wrapper>++</Wrapper>;
+
+export default CounterIcon;

--- a/packages/@logossim/components/Counter/CounterModel.js
+++ b/packages/@logossim/components/Counter/CounterModel.js
@@ -1,0 +1,33 @@
+import { BaseModel } from '@logossim/core';
+
+export default class CounterModel extends BaseModel {
+  initialize(configurations) {
+    this.dataBits = Number(configurations.DATA_BITS);
+    this.countOnRising = configurations.COUNT_ON === 'rising';
+    this.startAt = configurations.START_AT;
+    this.wrapAt = configurations.WRAP_AT || 2 ** this.dataBits;
+    this.stepValue = configurations.STEP_VALUE;
+
+    this.addInputPort('in');
+    this.addOutputPort('out', { bits: this.dataBits });
+
+    this.current = this.startAt;
+  }
+
+  isRisingEdge(meta) {
+    if (this.countOnRising) return meta.in.risingEdge;
+    return meta.in.fallingEdge;
+  }
+
+  step(input, meta) {
+    if (!this.isRisingEdge(meta)) return { out: this.current };
+
+    this.current += this.stepValue;
+
+    if (this.current >= this.wrapAt) this.current = this.startAt;
+
+    return {
+      out: this.current,
+    };
+  }
+}

--- a/packages/@logossim/components/Counter/CounterRegister.js
+++ b/packages/@logossim/components/Counter/CounterRegister.js
@@ -1,0 +1,114 @@
+import { Component } from '@logossim/core';
+import { MAX_VALUE } from '@logossim/core/Simulation/utils';
+
+import icon from './CounterIcon';
+import model from './CounterModel';
+import widget from './CounterWidget';
+
+export default new Component({
+  type: 'Counter',
+  name: 'Counter',
+  description: 'Counts every input rising or falling edge',
+  group: 'Miscellaneous',
+  configurations: [
+    {
+      name: 'DATA_BITS',
+      type: 'select',
+      default: '1',
+      label: 'Data bits',
+      options: [
+        {
+          label: '1 bit',
+          value: '1',
+        },
+        {
+          label: '2 bits',
+          value: '2',
+        },
+        {
+          label: '4 bits',
+          value: '4',
+        },
+        {
+          label: '8 bits',
+          value: '8',
+        },
+        {
+          label: '16 bits',
+          value: '16',
+        },
+      ],
+    },
+    {
+      name: 'COUNT_ON',
+      type: 'select',
+      default: 'rising',
+      label: 'Count on',
+      options: [
+        {
+          label: 'Rising edge',
+          value: 'rising',
+        },
+        {
+          label: 'Falling edge',
+          value: 'falling',
+        },
+      ],
+    },
+    {
+      name: 'START_AT',
+      type: 'number',
+      default: 0,
+      label: 'Start value at',
+      min: 0,
+      max: MAX_VALUE[16],
+      validate(value, configurations) {
+        const DATA_BITS = Number(configurations.DATA_BITS);
+
+        if (value > MAX_VALUE[DATA_BITS])
+          return `Maximum value for ${DATA_BITS}-bit is ${MAX_VALUE[DATA_BITS]}`;
+
+        return null;
+      },
+    },
+    {
+      name: 'WRAP_AT',
+      type: 'number',
+      default: 0,
+      label: 'Wrap value at (0 means no wrap)',
+      min: 0,
+      max: MAX_VALUE[16],
+      validate(value, configurations) {
+        const DATA_BITS = Number(configurations.DATA_BITS);
+        const START_AT = Number(configurations.START_AT);
+
+        if (value > MAX_VALUE[DATA_BITS])
+          return `Maximum value for ${DATA_BITS}-bit is ${MAX_VALUE[DATA_BITS]}`;
+
+        if (value !== 0 && value <= START_AT)
+          return `Value must be greater than ${START_AT} (start value)`;
+
+        return null;
+      },
+    },
+    {
+      name: 'STEP_VALUE',
+      type: 'number',
+      default: 1,
+      label: 'Step value',
+      min: 1,
+      max: MAX_VALUE[16],
+      validate(value, configurations) {
+        const DATA_BITS = Number(configurations.DATA_BITS);
+
+        if (value > MAX_VALUE[DATA_BITS])
+          return `Maximum value for ${DATA_BITS}-bit is ${MAX_VALUE[DATA_BITS]}`;
+
+        return null;
+      },
+    },
+  ],
+  model,
+  widget,
+  icon,
+});

--- a/packages/@logossim/components/Counter/CounterWidget.jsx
+++ b/packages/@logossim/components/Counter/CounterWidget.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { Port } from '@logossim/core';
+
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 30px;
+  height: 30px;
+
+  font-size: 12px;
+
+  transition: 100ms linear;
+
+  background: ${props =>
+    props.selected
+      ? 'var(--body-selected)'
+      : 'var(--body-unselected)'};
+
+  border: 2px solid
+    ${props =>
+      props.selected
+        ? 'var(--border-selected)'
+        : 'var(--border-unselected)'};
+`;
+
+const PositionedPort = styled(Port)`
+  position: absolute;
+  ${props => {
+    if (props.name === 'in') return 'left: -5px;';
+    if (props.name === 'out') return 'right: -5px;';
+    return '';
+  }}
+`;
+
+const CounterWidget = props => {
+  const { model } = props;
+  const {
+    options: { selected },
+  } = model;
+
+  return (
+    <Wrapper selected={selected}>
+      <PositionedPort name="in" />
+      <PositionedPort name="out" />
+      ++
+    </Wrapper>
+  );
+};
+
+export default CounterWidget;

--- a/packages/@logossim/components/Counter/__tests__/CounterModel.test.js
+++ b/packages/@logossim/components/Counter/__tests__/CounterModel.test.js
@@ -2,90 +2,92 @@ import CounterModel from '../CounterModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const addInputSpy = jest.spyOn(
-    CounterModel.prototype,
-    'addInputPort',
-  );
-  addInputSpy.mockImplementation(addPort);
+describe('CounterModel', () => {
+  it('should add ports on initialization', () => {
+    const addInputSpy = jest.spyOn(
+      CounterModel.prototype,
+      'addInputPort',
+    );
+    addInputSpy.mockImplementation(addPort);
 
-  const addOutputSpy = jest.spyOn(
-    CounterModel.prototype,
-    'addOutputPort',
-  );
-  addOutputSpy.mockImplementation(addPort);
+    const addOutputSpy = jest.spyOn(
+      CounterModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  new CounterModel({
-    DATA_BITS: 4,
-    COUNT_ON: 'rising',
-    START_AT: 0,
-    WRAP_AT: 0,
-    STEP_VALUE: 1,
+    new CounterModel({
+      DATA_BITS: 4,
+      COUNT_ON: 'rising',
+      START_AT: 0,
+      WRAP_AT: 0,
+      STEP_VALUE: 1,
+    });
+
+    expect(addInputSpy).toHaveBeenCalledWith('in');
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
   });
 
-  expect(addInputSpy).toHaveBeenCalledWith('in');
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
-});
+  it('should start at START_VALUE', () => {
+    const model = new CounterModel({
+      DATA_BITS: 4,
+      COUNT_ON: 'rising',
+      START_AT: 10,
+      WRAP_AT: 0,
+      STEP_VALUE: 1,
+    });
 
-it('should start at START_VALUE', () => {
-  const model = new CounterModel({
-    DATA_BITS: 4,
-    COUNT_ON: 'rising',
-    START_AT: 10,
-    WRAP_AT: 0,
-    STEP_VALUE: 1,
+    const { out } = model.step({}, { in: { risingEdge: false } });
+
+    expect(out).toEqual(10);
   });
 
-  const { out } = model.step({}, { in: { risingEdge: false } });
+  it('should increment by STEP_VALUE on rising edge if configured', () => {
+    const model = new CounterModel({
+      DATA_BITS: 4,
+      COUNT_ON: 'rising',
+      START_AT: 10,
+      WRAP_AT: 0,
+      STEP_VALUE: 2,
+    });
 
-  expect(out).toEqual(10);
-});
+    const { out } = model.step({}, { in: { risingEdge: true } });
 
-it('should increment by STEP_VALUE on rising edge if configured', () => {
-  const model = new CounterModel({
-    DATA_BITS: 4,
-    COUNT_ON: 'rising',
-    START_AT: 10,
-    WRAP_AT: 0,
-    STEP_VALUE: 2,
+    expect(out).toEqual(12);
   });
 
-  const { out } = model.step({}, { in: { risingEdge: true } });
+  it('should increment by STEP_VALUE on falling edge if configured', () => {
+    const model = new CounterModel({
+      DATA_BITS: 4,
+      COUNT_ON: 'falling',
+      START_AT: 10,
+      WRAP_AT: 0,
+      STEP_VALUE: 2,
+    });
 
-  expect(out).toEqual(12);
-});
+    const { out } = model.step({}, { in: { fallingEdge: true } });
 
-it('should increment by STEP_VALUE on falling edge if configured', () => {
-  const model = new CounterModel({
-    DATA_BITS: 4,
-    COUNT_ON: 'falling',
-    START_AT: 10,
-    WRAP_AT: 0,
-    STEP_VALUE: 2,
+    expect(out).toEqual(12);
   });
 
-  const { out } = model.step({}, { in: { fallingEdge: true } });
+  it('should wrap if configured', () => {
+    const model = new CounterModel({
+      DATA_BITS: 4,
+      COUNT_ON: 'rising',
+      START_AT: 10,
+      WRAP_AT: 14,
+      STEP_VALUE: 1,
+    });
 
-  expect(out).toEqual(12);
-});
+    // 10 => 11
+    model.step({}, { in: { risingEdge: true } });
+    // 11 => 12
+    model.step({}, { in: { risingEdge: true } });
+    // 12 => 13
+    model.step({}, { in: { risingEdge: true } });
+    // 13 => 14 => 0 (wrap)
+    const { out } = model.step({}, { in: { risingEdge: true } });
 
-it('should wrap if configured', () => {
-  const model = new CounterModel({
-    DATA_BITS: 4,
-    COUNT_ON: 'rising',
-    START_AT: 10,
-    WRAP_AT: 14,
-    STEP_VALUE: 1,
+    expect(out).toEqual(10);
   });
-
-  // 10 => 11
-  model.step({}, { in: { risingEdge: true } });
-  // 11 => 12
-  model.step({}, { in: { risingEdge: true } });
-  // 12 => 13
-  model.step({}, { in: { risingEdge: true } });
-  // 13 => 14 => 0 (wrap)
-  const { out } = model.step({}, { in: { risingEdge: true } });
-
-  expect(out).toEqual(10);
 });

--- a/packages/@logossim/components/Counter/__tests__/CounterModel.test.js
+++ b/packages/@logossim/components/Counter/__tests__/CounterModel.test.js
@@ -1,0 +1,91 @@
+import CounterModel from '../CounterModel';
+
+const { addPort } = global;
+
+it('should add ports on initialization', () => {
+  const addInputSpy = jest.spyOn(
+    CounterModel.prototype,
+    'addInputPort',
+  );
+  addInputSpy.mockImplementation(addPort);
+
+  const addOutputSpy = jest.spyOn(
+    CounterModel.prototype,
+    'addOutputPort',
+  );
+  addOutputSpy.mockImplementation(addPort);
+
+  new CounterModel({
+    DATA_BITS: 4,
+    COUNT_ON: 'rising',
+    START_AT: 0,
+    WRAP_AT: 0,
+    STEP_VALUE: 1,
+  });
+
+  expect(addInputSpy).toHaveBeenCalledWith('in');
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
+});
+
+it('should start at START_VALUE', () => {
+  const model = new CounterModel({
+    DATA_BITS: 4,
+    COUNT_ON: 'rising',
+    START_AT: 10,
+    WRAP_AT: 0,
+    STEP_VALUE: 1,
+  });
+
+  const { out } = model.step({}, { in: { risingEdge: false } });
+
+  expect(out).toEqual(10);
+});
+
+it('should increment by STEP_VALUE on rising edge if configured', () => {
+  const model = new CounterModel({
+    DATA_BITS: 4,
+    COUNT_ON: 'rising',
+    START_AT: 10,
+    WRAP_AT: 0,
+    STEP_VALUE: 2,
+  });
+
+  const { out } = model.step({}, { in: { risingEdge: true } });
+
+  expect(out).toEqual(12);
+});
+
+it('should increment by STEP_VALUE on falling edge if configured', () => {
+  const model = new CounterModel({
+    DATA_BITS: 4,
+    COUNT_ON: 'falling',
+    START_AT: 10,
+    WRAP_AT: 0,
+    STEP_VALUE: 2,
+  });
+
+  const { out } = model.step({}, { in: { fallingEdge: true } });
+
+  expect(out).toEqual(12);
+});
+
+it('should wrap if configured', () => {
+  const model = new CounterModel({
+    DATA_BITS: 4,
+    COUNT_ON: 'rising',
+    START_AT: 10,
+    WRAP_AT: 14,
+    STEP_VALUE: 1,
+  });
+
+  // 10 => 11
+  model.step({}, { in: { risingEdge: true } });
+  // 11 => 12
+  model.step({}, { in: { risingEdge: true } });
+  // 12 => 13
+  model.step({}, { in: { risingEdge: true } });
+  // 13 => 14 => 0 (wrap)
+  const { out } = model.step({}, { in: { risingEdge: true } });
+
+  expect(out).toEqual(10);
+});

--- a/packages/@logossim/components/Counter/__tests__/CounterWidget.test.jsx
+++ b/packages/@logossim/components/Counter/__tests__/CounterWidget.test.jsx
@@ -4,16 +4,18 @@ import { render } from '../../testUtils';
 import CounterModel from '../CounterModel';
 import CounterWidget from '../CounterWidget';
 
-it('should have 1 input and 1 output port', () => {
-  const model = new CounterModel({
-    DATA_BITS: 1,
+describe('CounterWidget', () => {
+  it('should have 1 input and 1 output port', () => {
+    const model = new CounterModel({
+      DATA_BITS: 1,
+    });
+
+    const { container } = render(<CounterWidget model={model} />);
+
+    const input = container.querySelector('[data-name=in]');
+    expect(input).toBeTruthy();
+
+    const output = container.querySelector('[data-name=out]');
+    expect(output).toBeTruthy();
   });
-
-  const { container } = render(<CounterWidget model={model} />);
-
-  const input = container.querySelector('[data-name=in]');
-  expect(input).toBeTruthy();
-
-  const output = container.querySelector('[data-name=out]');
-  expect(output).toBeTruthy();
 });

--- a/packages/@logossim/components/Counter/__tests__/CounterWidget.test.jsx
+++ b/packages/@logossim/components/Counter/__tests__/CounterWidget.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { render } from '../../testUtils';
+import CounterModel from '../CounterModel';
+import CounterWidget from '../CounterWidget';
+
+it('should have 1 input and 1 output port', () => {
+  const model = new CounterModel({
+    DATA_BITS: 1,
+  });
+
+  const { container } = render(<CounterWidget model={model} />);
+
+  const input = container.querySelector('[data-name=in]');
+  expect(input).toBeTruthy();
+
+  const output = container.querySelector('[data-name=out]');
+  expect(output).toBeTruthy();
+});

--- a/packages/@logossim/components/Demux/DemuxModel.js
+++ b/packages/@logossim/components/Demux/DemuxModel.js
@@ -5,11 +5,13 @@ export default class DemuxModel extends BaseModel {
     const DATA_BITS = Number(configurations.DATA_BITS);
     this.outputNumber = Number(configurations.OUTPUT_NUMBER);
 
-    this.addInputPort('in', DATA_BITS);
-    this.addInputPort('selection', Math.log2(this.outputNumber));
+    this.addInputPort('in', { bits: DATA_BITS });
+    this.addInputPort('selection', {
+      bits: Math.log2(this.outputNumber),
+    });
 
     for (let i = 0; i < this.outputNumber; i += 1) {
-      this.addOutputPort(`out${i}`, DATA_BITS);
+      this.addOutputPort(`out${i}`, { bits: DATA_BITS });
     }
   }
 

--- a/packages/@logossim/components/Demux/DemuxWidget.jsx
+++ b/packages/@logossim/components/Demux/DemuxWidget.jsx
@@ -48,7 +48,7 @@ export const Shape = ({ selected, outputNumber, icon }) => {
 };
 
 const DemuxWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
   } = model;
@@ -61,20 +61,14 @@ const DemuxWidget = props => {
       <PositionedPort
         name="in"
         model={model}
-        engine={engine}
         position={((outputNumber + 2) * 15) / 2}
       />
-      <PositionedPort
-        name="selection"
-        model={model}
-        engine={engine}
-      />
+      <PositionedPort name="selection" model={model} />
       {outputPorts.map((port, i) => (
         <PositionedPort
           key={port.getName()}
           name={port.getName()}
           model={model}
-          engine={engine}
           position={(i + 1) * 15}
         />
       ))}

--- a/packages/@logossim/components/Demux/DemuxWidget.jsx
+++ b/packages/@logossim/components/Demux/DemuxWidget.jsx
@@ -60,15 +60,13 @@ const DemuxWidget = props => {
     <Wrapper outputNumber={outputNumber}>
       <PositionedPort
         name="in"
-        model={model}
         position={((outputNumber + 2) * 15) / 2}
       />
-      <PositionedPort name="selection" model={model} />
+      <PositionedPort name="selection" />
       {outputPorts.map((port, i) => (
         <PositionedPort
           key={port.getName()}
           name={port.getName()}
-          model={model}
           position={(i + 1) * 15}
         />
       ))}

--- a/packages/@logossim/components/Demux/DemuxWidget.jsx
+++ b/packages/@logossim/components/Demux/DemuxWidget.jsx
@@ -61,14 +61,12 @@ const DemuxWidget = props => {
       <PositionedPort
         name="in"
         model={model}
-        port={model.getPort('in')}
         engine={engine}
         position={((outputNumber + 2) * 15) / 2}
       />
       <PositionedPort
         name="selection"
         model={model}
-        port={model.getPort('selection')}
         engine={engine}
       />
       {outputPorts.map((port, i) => (
@@ -76,7 +74,6 @@ const DemuxWidget = props => {
           key={port.getName()}
           name={port.getName()}
           model={model}
-          port={port}
           engine={engine}
           position={(i + 1) * 15}
         />

--- a/packages/@logossim/components/Demux/__tests__/DemuxModel.test.js
+++ b/packages/@logossim/components/Demux/__tests__/DemuxModel.test.js
@@ -1,6 +1,3 @@
-/* eslint-disable no-new */
-import { convertNumberValueToArray } from '@logossim/core/Simulation/utils';
-
 import DemuxModel from '../DemuxModel';
 
 const { addPort } = global;
@@ -86,7 +83,7 @@ it('should correctly forward the input based on selection value', () => {
       out13: [0, 0, 0, 0],
       out14: [0, 0, 0, 0],
       out15: [0, 0, 0, 0],
-      [`out${i}`]: convertNumberValueToArray(0b1010, DATA_BITS),
+      [`out${i}`]: (0b1010).asArray(DATA_BITS),
     });
   });
 });

--- a/packages/@logossim/components/Demux/__tests__/DemuxModel.test.js
+++ b/packages/@logossim/components/Demux/__tests__/DemuxModel.test.js
@@ -53,37 +53,35 @@ it('should add ports on initialization (16 outputs)', () => {
 });
 
 it('should correctly forward the input based on selection value', () => {
-  const DATA_BITS = 4;
-
   const model = new DemuxModel({
-    DATA_BITS,
+    DATA_BITS: 4,
     OUTPUT_NUMBER: 16,
   });
 
   [...Array(16).keys()].forEach(i => {
     expect(
-      model.stepAndMask({
+      model.step({
         selection: i,
         in: 0b1010,
       }),
     ).toEqual({
-      out0: [0, 0, 0, 0],
-      out1: [0, 0, 0, 0],
-      out2: [0, 0, 0, 0],
-      out3: [0, 0, 0, 0],
-      out4: [0, 0, 0, 0],
-      out5: [0, 0, 0, 0],
-      out6: [0, 0, 0, 0],
-      out7: [0, 0, 0, 0],
-      out8: [0, 0, 0, 0],
-      out9: [0, 0, 0, 0],
-      out10: [0, 0, 0, 0],
-      out11: [0, 0, 0, 0],
-      out12: [0, 0, 0, 0],
-      out13: [0, 0, 0, 0],
-      out14: [0, 0, 0, 0],
-      out15: [0, 0, 0, 0],
-      [`out${i}`]: (0b1010).asArray(DATA_BITS),
+      out0: 0,
+      out1: 0,
+      out2: 0,
+      out3: 0,
+      out4: 0,
+      out5: 0,
+      out6: 0,
+      out7: 0,
+      out8: 0,
+      out9: 0,
+      out10: 0,
+      out11: 0,
+      out12: 0,
+      out13: 0,
+      out14: 0,
+      out15: 0,
+      [`out${i}`]: 0b1010,
     });
   });
 });

--- a/packages/@logossim/components/Demux/__tests__/DemuxModel.test.js
+++ b/packages/@logossim/components/Demux/__tests__/DemuxModel.test.js
@@ -11,77 +11,89 @@ const addOutputSpy = jest.spyOn(
 );
 addOutputSpy.mockImplementation(addPort);
 
-it('should add ports on initialization (2 outputs)', () => {
-  new DemuxModel({
-    DATA_BITS: 16,
-    OUTPUT_NUMBER: 2,
-  });
+describe('DemuxModel', () => {
+  it('should add ports on initialization (2 outputs)', () => {
+    new DemuxModel({
+      DATA_BITS: 16,
+      OUTPUT_NUMBER: 2,
+    });
 
-  expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 16 });
-  expect(addInputSpy).toHaveBeenCalledWith('selection', { bits: 1 });
-  [...Array(2).keys()].forEach(i => {
-    expect(addOutputSpy).toHaveBeenCalledWith(`out${i}`, {
-      bits: 16,
+    expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 16 });
+    expect(addInputSpy).toHaveBeenCalledWith('selection', {
+      bits: 1,
+    });
+    [...Array(2).keys()].forEach(i => {
+      expect(addOutputSpy).toHaveBeenCalledWith(`out${i}`, {
+        bits: 16,
+      });
     });
   });
-});
 
-it('should add ports on initialization (4 outputs)', () => {
-  new DemuxModel({
-    DATA_BITS: 4,
-    OUTPUT_NUMBER: 4,
+  it('should add ports on initialization (4 outputs)', () => {
+    new DemuxModel({
+      DATA_BITS: 4,
+      OUTPUT_NUMBER: 4,
+    });
+
+    expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 4 });
+    expect(addInputSpy).toHaveBeenCalledWith('selection', {
+      bits: 2,
+    });
+    [...Array(4).keys()].forEach(i => {
+      expect(addOutputSpy).toHaveBeenCalledWith(`out${i}`, {
+        bits: 4,
+      });
+    });
   });
 
-  expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 4 });
-  expect(addInputSpy).toHaveBeenCalledWith('selection', { bits: 2 });
-  [...Array(4).keys()].forEach(i => {
-    expect(addOutputSpy).toHaveBeenCalledWith(`out${i}`, { bits: 4 });
-  });
-});
+  it('should add ports on initialization (16 outputs)', () => {
+    new DemuxModel({
+      DATA_BITS: 1,
+      OUTPUT_NUMBER: 16,
+    });
 
-it('should add ports on initialization (16 outputs)', () => {
-  new DemuxModel({
-    DATA_BITS: 1,
-    OUTPUT_NUMBER: 16,
-  });
-
-  expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 1 });
-  expect(addInputSpy).toHaveBeenCalledWith('selection', { bits: 4 });
-  [...Array(16).keys()].forEach(i => {
-    expect(addOutputSpy).toHaveBeenCalledWith(`out${i}`, { bits: 1 });
-  });
-});
-
-it('should correctly forward the input based on selection value', () => {
-  const model = new DemuxModel({
-    DATA_BITS: 4,
-    OUTPUT_NUMBER: 16,
+    expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 1 });
+    expect(addInputSpy).toHaveBeenCalledWith('selection', {
+      bits: 4,
+    });
+    [...Array(16).keys()].forEach(i => {
+      expect(addOutputSpy).toHaveBeenCalledWith(`out${i}`, {
+        bits: 1,
+      });
+    });
   });
 
-  [...Array(16).keys()].forEach(i => {
-    expect(
-      model.step({
-        selection: i,
-        in: 0b1010,
-      }),
-    ).toEqual({
-      out0: 0,
-      out1: 0,
-      out2: 0,
-      out3: 0,
-      out4: 0,
-      out5: 0,
-      out6: 0,
-      out7: 0,
-      out8: 0,
-      out9: 0,
-      out10: 0,
-      out11: 0,
-      out12: 0,
-      out13: 0,
-      out14: 0,
-      out15: 0,
-      [`out${i}`]: 0b1010,
+  it('should correctly forward the input based on selection value', () => {
+    const model = new DemuxModel({
+      DATA_BITS: 4,
+      OUTPUT_NUMBER: 16,
+    });
+
+    [...Array(16).keys()].forEach(i => {
+      expect(
+        model.step({
+          selection: i,
+          in: 0b1010,
+        }),
+      ).toEqual({
+        out0: 0,
+        out1: 0,
+        out2: 0,
+        out3: 0,
+        out4: 0,
+        out5: 0,
+        out6: 0,
+        out7: 0,
+        out8: 0,
+        out9: 0,
+        out10: 0,
+        out11: 0,
+        out12: 0,
+        out13: 0,
+        out14: 0,
+        out15: 0,
+        [`out${i}`]: 0b1010,
+      });
     });
   });
 });

--- a/packages/@logossim/components/Demux/__tests__/DemuxModel.test.js
+++ b/packages/@logossim/components/Demux/__tests__/DemuxModel.test.js
@@ -20,10 +20,12 @@ it('should add ports on initialization (2 outputs)', () => {
     OUTPUT_NUMBER: 2,
   });
 
-  expect(addInputSpy).toHaveBeenCalledWith('in', 16);
-  expect(addInputSpy).toHaveBeenCalledWith('selection', 1);
+  expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 16 });
+  expect(addInputSpy).toHaveBeenCalledWith('selection', { bits: 1 });
   [...Array(2).keys()].forEach(i => {
-    expect(addOutputSpy).toHaveBeenCalledWith(`out${i}`, 16);
+    expect(addOutputSpy).toHaveBeenCalledWith(`out${i}`, {
+      bits: 16,
+    });
   });
 });
 
@@ -33,10 +35,10 @@ it('should add ports on initialization (4 outputs)', () => {
     OUTPUT_NUMBER: 4,
   });
 
-  expect(addInputSpy).toHaveBeenCalledWith('in', 4);
-  expect(addInputSpy).toHaveBeenCalledWith('selection', 2);
+  expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 4 });
+  expect(addInputSpy).toHaveBeenCalledWith('selection', { bits: 2 });
   [...Array(4).keys()].forEach(i => {
-    expect(addOutputSpy).toHaveBeenCalledWith(`out${i}`, 4);
+    expect(addOutputSpy).toHaveBeenCalledWith(`out${i}`, { bits: 4 });
   });
 });
 
@@ -46,10 +48,10 @@ it('should add ports on initialization (16 outputs)', () => {
     OUTPUT_NUMBER: 16,
   });
 
-  expect(addInputSpy).toHaveBeenCalledWith('in', 1);
-  expect(addInputSpy).toHaveBeenCalledWith('selection', 4);
+  expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 1 });
+  expect(addInputSpy).toHaveBeenCalledWith('selection', { bits: 4 });
   [...Array(16).keys()].forEach(i => {
-    expect(addOutputSpy).toHaveBeenCalledWith(`out${i}`, 1);
+    expect(addOutputSpy).toHaveBeenCalledWith(`out${i}`, { bits: 1 });
   });
 });
 

--- a/packages/@logossim/components/Demux/__tests__/DemuxWidget.test.jsx
+++ b/packages/@logossim/components/Demux/__tests__/DemuxWidget.test.jsx
@@ -4,29 +4,33 @@ import { render } from '../../testUtils';
 import DemuxModel from '../DemuxModel';
 import DemuxWidget from '../DemuxWidget';
 
-it('should have 1 selection and 1 input port', () => {
-  const model = new DemuxModel({
-    DATA_BITS: 1,
-    OUTPUT_NUMBER: 16,
+describe('DemuxWidget', () => {
+  it('should have 1 selection and 1 input port', () => {
+    const model = new DemuxModel({
+      DATA_BITS: 1,
+      OUTPUT_NUMBER: 16,
+    });
+
+    const { container } = render(<DemuxWidget model={model} />);
+
+    const selection = container.querySelector(
+      '[data-name=selection]',
+    );
+    const input = container.querySelector('[data-name=in]');
+
+    expect(selection).toBeTruthy();
+    expect(input).toBeTruthy();
   });
 
-  const { container } = render(<DemuxWidget model={model} />);
+  it('should have the amount of output ports determined by configuration', () => {
+    const model = new DemuxModel({
+      DATA_BITS: 16,
+      OUTPUT_NUMBER: 4,
+    });
 
-  const selection = container.querySelector('[data-name=selection]');
-  const input = container.querySelector('[data-name=in]');
+    const { container } = render(<DemuxWidget model={model} />);
 
-  expect(selection).toBeTruthy();
-  expect(input).toBeTruthy();
-});
-
-it('should have the amount of output ports determined by configuration', () => {
-  const model = new DemuxModel({
-    DATA_BITS: 16,
-    OUTPUT_NUMBER: 4,
+    const ports = container.querySelectorAll('[data-name^=out]');
+    expect(ports).toHaveLength(4);
   });
-
-  const { container } = render(<DemuxWidget model={model} />);
-
-  const ports = container.querySelectorAll('[data-name^=out]');
-  expect(ports).toHaveLength(4);
 });

--- a/packages/@logossim/components/Demux/__tests__/DemuxWidget.test.jsx
+++ b/packages/@logossim/components/Demux/__tests__/DemuxWidget.test.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import DemuxModel from '../DemuxModel';
 import DemuxWidget from '../DemuxWidget';
-
-const { engine } = global;
 
 it('should have 1 selection and 1 input port', () => {
   const model = new DemuxModel({
@@ -13,9 +10,7 @@ it('should have 1 selection and 1 input port', () => {
     OUTPUT_NUMBER: 16,
   });
 
-  const { container } = render(
-    <DemuxWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<DemuxWidget model={model} />);
 
   const selection = container.querySelector('[data-name=selection]');
   const input = container.querySelector('[data-name=in]');
@@ -30,9 +25,7 @@ it('should have the amount of output ports determined by configuration', () => {
     OUTPUT_NUMBER: 4,
   });
 
-  const { container } = render(
-    <DemuxWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<DemuxWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name^=out]');
   expect(ports).toHaveLength(4);

--- a/packages/@logossim/components/Ground/GroundModel.js
+++ b/packages/@logossim/components/Ground/GroundModel.js
@@ -4,7 +4,7 @@ export default class GroundModel extends BaseModel {
   initialize(configurations) {
     this.dataBits = Number(configurations.DATA_BITS);
 
-    this.addOutputPort('out', this.dataBits);
+    this.addOutputPort('out', { bits: this.dataBits });
   }
 
   onSimulationStart() {

--- a/packages/@logossim/components/Ground/GroundWidget.jsx
+++ b/packages/@logossim/components/Ground/GroundWidget.jsx
@@ -44,7 +44,7 @@ export const Shape = ({ selected, dataBits = 1 }) => {
 };
 
 const GroundWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
   } = model;
@@ -52,7 +52,7 @@ const GroundWidget = props => {
   return (
     <Wrapper>
       <Shape selected={selected} dataBits={model.dataBits} />
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} />
     </Wrapper>
   );
 };

--- a/packages/@logossim/components/Ground/GroundWidget.jsx
+++ b/packages/@logossim/components/Ground/GroundWidget.jsx
@@ -52,7 +52,7 @@ const GroundWidget = props => {
   return (
     <Wrapper>
       <Shape selected={selected} dataBits={model.dataBits} />
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="out" />
     </Wrapper>
   );
 };

--- a/packages/@logossim/components/Ground/GroundWidget.jsx
+++ b/packages/@logossim/components/Ground/GroundWidget.jsx
@@ -52,12 +52,7 @@ const GroundWidget = props => {
   return (
     <Wrapper>
       <Shape selected={selected} dataBits={model.dataBits} />
-      <PositionedPort
-        name="out"
-        model={model}
-        port={model.getPort('out')}
-        engine={engine}
-      />
+      <PositionedPort name="out" model={model} engine={engine} />
     </Wrapper>
   );
 };

--- a/packages/@logossim/components/Ground/__tests__/GroundModel.test.js
+++ b/packages/@logossim/components/Ground/__tests__/GroundModel.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import GroundModel from '../GroundModel';
 
 const { addPort } = global;

--- a/packages/@logossim/components/Ground/__tests__/GroundModel.test.js
+++ b/packages/@logossim/components/Ground/__tests__/GroundModel.test.js
@@ -14,7 +14,7 @@ it('should add output port on initialization', () => {
     DATA_BITS: 16,
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', 16);
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 16 });
 });
 
 it('should always return low values', () => {

--- a/packages/@logossim/components/Ground/__tests__/GroundModel.test.js
+++ b/packages/@logossim/components/Ground/__tests__/GroundModel.test.js
@@ -2,27 +2,29 @@ import GroundModel from '../GroundModel';
 
 const { addPort } = global;
 
-it('should add output port on initialization', () => {
-  const addOutputSpy = jest.spyOn(
-    GroundModel.prototype,
-    'addOutputPort',
-  );
-  addOutputSpy.mockImplementation(addPort);
+describe('GroundModel', () => {
+  it('should add output port on initialization', () => {
+    const addOutputSpy = jest.spyOn(
+      GroundModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  new GroundModel({
-    DATA_BITS: 16,
+    new GroundModel({
+      DATA_BITS: 16,
+    });
+
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 16 });
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 16 });
-});
+  it('should always return low values', () => {
+    const model = new GroundModel({
+      DATA_BITS: 16,
+    });
+    const spy = jest.spyOn(model, 'emit');
 
-it('should always return low values', () => {
-  const model = new GroundModel({
-    DATA_BITS: 16,
+    model.onSimulationStart();
+
+    expect(spy).toHaveBeenCalledWith({ out: 0 });
   });
-  const spy = jest.spyOn(model, 'emit');
-
-  model.onSimulationStart();
-
-  expect(spy).toHaveBeenCalledWith({ out: 0 });
 });

--- a/packages/@logossim/components/Ground/__tests__/GroundWidget.test.jsx
+++ b/packages/@logossim/components/Ground/__tests__/GroundWidget.test.jsx
@@ -4,13 +4,15 @@ import { render } from '../../testUtils';
 import GroundModel from '../GroundModel';
 import GroundWidget from '../GroundWidget';
 
-it('should have 1 output port', () => {
-  const model = new GroundModel({
-    DATA_BITS: 1,
+describe('GroundWidget', () => {
+  it('should have 1 output port', () => {
+    const model = new GroundModel({
+      DATA_BITS: 1,
+    });
+
+    const { container } = render(<GroundWidget model={model} />);
+
+    const port = container.querySelector('[data-name=out]');
+    expect(port).toBeTruthy();
   });
-
-  const { container } = render(<GroundWidget model={model} />);
-
-  const port = container.querySelector('[data-name=out]');
-  expect(port).toBeTruthy();
 });

--- a/packages/@logossim/components/Ground/__tests__/GroundWidget.test.jsx
+++ b/packages/@logossim/components/Ground/__tests__/GroundWidget.test.jsx
@@ -1,20 +1,15 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import GroundModel from '../GroundModel';
 import GroundWidget from '../GroundWidget';
-
-const { engine } = global;
 
 it('should have 1 output port', () => {
   const model = new GroundModel({
     DATA_BITS: 1,
   });
 
-  const { container } = render(
-    <GroundWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<GroundWidget model={model} />);
 
   const port = container.querySelector('[data-name=out]');
   expect(port).toBeTruthy();

--- a/packages/@logossim/components/Input/InputModel.js
+++ b/packages/@logossim/components/Input/InputModel.js
@@ -5,7 +5,7 @@ export default class InputModel extends BaseModel {
     this.dataBits = Number(configurations.DATA_BITS);
     this.threeState = configurations.THREE_STATE === 'true';
 
-    this.addOutputPort('out', this.dataBits);
+    this.addOutputPort('out', { bits: this.dataBits });
   }
 
   onSimulationStart() {

--- a/packages/@logossim/components/Input/InputWidget.jsx
+++ b/packages/@logossim/components/Input/InputWidget.jsx
@@ -108,7 +108,7 @@ const InputWidget = props => {
           );
         })}
       </PinContainer>
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="out" />
     </Shape>
   );
 };

--- a/packages/@logossim/components/Input/InputWidget.jsx
+++ b/packages/@logossim/components/Input/InputWidget.jsx
@@ -82,7 +82,7 @@ export const Pin = styled.button`
 `;
 
 const InputWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
     configurations: { DATA_BITS },
@@ -108,7 +108,7 @@ const InputWidget = props => {
           );
         })}
       </PinContainer>
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} />
     </Shape>
   );
 };

--- a/packages/@logossim/components/Input/InputWidget.jsx
+++ b/packages/@logossim/components/Input/InputWidget.jsx
@@ -55,7 +55,7 @@ export const Shape = styled.div`
 
 export const PinContainer = styled.div`
   display: flex;
-  flex-wrap: wrap-reverse;
+  flex-wrap: wrap;
   justify-content: space-evenly;
   align-items: center;
 

--- a/packages/@logossim/components/Input/InputWidget.jsx
+++ b/packages/@logossim/components/Input/InputWidget.jsx
@@ -108,12 +108,7 @@ const InputWidget = props => {
           );
         })}
       </PinContainer>
-      <PositionedPort
-        name="out"
-        model={model}
-        port={model.getPort('out')}
-        engine={engine}
-      />
+      <PositionedPort name="out" model={model} engine={engine} />
     </Shape>
   );
 };

--- a/packages/@logossim/components/Input/__tests__/InputModel.test.js
+++ b/packages/@logossim/components/Input/__tests__/InputModel.test.js
@@ -9,7 +9,7 @@ it('should add ports on initialization', () => {
 
   new InputModel({ DATA_BITS: 1 });
 
-  expect(spy).toHaveBeenCalledWith('out', 1);
+  expect(spy).toHaveBeenCalledWith('out', { bits: 1 });
 });
 
 it('should emit on simulation start', () => {

--- a/packages/@logossim/components/Input/__tests__/InputModel.test.js
+++ b/packages/@logossim/components/Input/__tests__/InputModel.test.js
@@ -2,49 +2,56 @@ import InputModel from '../InputModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const spy = jest.spyOn(InputModel.prototype, 'addOutputPort');
-  spy.mockImplementation(addPort);
+describe('InputModel', () => {
+  it('should add ports on initialization', () => {
+    const spy = jest.spyOn(InputModel.prototype, 'addOutputPort');
+    spy.mockImplementation(addPort);
 
-  new InputModel({ DATA_BITS: 1 });
+    new InputModel({ DATA_BITS: 1 });
 
-  expect(spy).toHaveBeenCalledWith('out', { bits: 1 });
-});
-
-it('should emit on simulation start', () => {
-  const model = new InputModel({ DATA_BITS: 1 });
-  const spy = jest.spyOn(model, 'emit');
-  model.onSimulationStart();
-
-  expect(spy).toHaveBeenCalledWith({ out: 0 });
-});
-
-it('should emit toggling value on click', () => {
-  const model = new InputModel({ DATA_BITS: 2 });
-  const emitSpy = jest.spyOn(model, 'emit');
-  const outputSpy = jest.spyOn(model, 'getOutput');
-  outputSpy.mockImplementation(() => [0, 1]);
-
-  model.onClick(0);
-  model.onClick(1);
-
-  expect(emitSpy).toHaveBeenNthCalledWith(1, { out: [1, 1] });
-  expect(emitSpy).toHaveBeenNthCalledWith(2, { out: [0, 0] });
-});
-
-it('should emit correctly for three state value on click', () => {
-  const model = new InputModel({ DATA_BITS: 4, THREE_STATE: 'true' });
-  const emitSpy = jest.spyOn(model, 'emit');
-  const outputSpy = jest.spyOn(model, 'getOutput');
-  outputSpy.mockImplementation(() => [0, 1, 'x', 0]);
-
-  model.onClick(0);
-  model.onClick(1);
-  model.onClick(2);
-
-  expect(emitSpy).toHaveBeenNthCalledWith(1, { out: [1, 1, 'x', 0] });
-  expect(emitSpy).toHaveBeenNthCalledWith(2, {
-    out: [0, 'x', 'x', 0],
+    expect(spy).toHaveBeenCalledWith('out', { bits: 1 });
   });
-  expect(emitSpy).toHaveBeenNthCalledWith(3, { out: [0, 1, 0, 0] });
+
+  it('should emit on simulation start', () => {
+    const model = new InputModel({ DATA_BITS: 1 });
+    const spy = jest.spyOn(model, 'emit');
+    model.onSimulationStart();
+
+    expect(spy).toHaveBeenCalledWith({ out: 0 });
+  });
+
+  it('should emit toggling value on click', () => {
+    const model = new InputModel({ DATA_BITS: 2 });
+    const emitSpy = jest.spyOn(model, 'emit');
+    const outputSpy = jest.spyOn(model, 'getOutput');
+    outputSpy.mockImplementation(() => [0, 1]);
+
+    model.onClick(0);
+    model.onClick(1);
+
+    expect(emitSpy).toHaveBeenNthCalledWith(1, { out: [1, 1] });
+    expect(emitSpy).toHaveBeenNthCalledWith(2, { out: [0, 0] });
+  });
+
+  it('should emit correctly for three state value on click', () => {
+    const model = new InputModel({
+      DATA_BITS: 4,
+      THREE_STATE: 'true',
+    });
+    const emitSpy = jest.spyOn(model, 'emit');
+    const outputSpy = jest.spyOn(model, 'getOutput');
+    outputSpy.mockImplementation(() => [0, 1, 'x', 0]);
+
+    model.onClick(0);
+    model.onClick(1);
+    model.onClick(2);
+
+    expect(emitSpy).toHaveBeenNthCalledWith(1, {
+      out: [1, 1, 'x', 0],
+    });
+    expect(emitSpy).toHaveBeenNthCalledWith(2, {
+      out: [0, 'x', 'x', 0],
+    });
+    expect(emitSpy).toHaveBeenNthCalledWith(3, { out: [0, 1, 0, 0] });
+  });
 });

--- a/packages/@logossim/components/Input/__tests__/InputModel.test.js
+++ b/packages/@logossim/components/Input/__tests__/InputModel.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import InputModel from '../InputModel';
 
 const { addPort } = global;

--- a/packages/@logossim/components/Input/__tests__/InputWidget.test.jsx
+++ b/packages/@logossim/components/Input/__tests__/InputWidget.test.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { convertNumberValueToArray } from '@logossim/core/Simulation/utils';
-
 import { render } from '../../testUtils';
 import InputModel from '../InputModel';
 import InputWidget from '../InputWidget';
@@ -66,7 +64,7 @@ it('should display pin values accordingly', () => {
   const model = new InputModel({ DATA_BITS });
   const spy = jest.spyOn(model, 'getOutput');
   spy.mockImplementation(() =>
-    convertNumberValueToArray(0b1010_1010_1010_1010, DATA_BITS),
+    (0b1010_1010_1010_1010).asArray(DATA_BITS),
   );
 
   const { getAllByRole } = render(<InputWidget model={model} />);

--- a/packages/@logossim/components/Input/__tests__/InputWidget.test.jsx
+++ b/packages/@logossim/components/Input/__tests__/InputWidget.test.jsx
@@ -4,100 +4,102 @@ import { render } from '../../testUtils';
 import InputModel from '../InputModel';
 import InputWidget from '../InputWidget';
 
-it('should have 1 output port', () => {
-  const model = new InputModel({ DATA_BITS: 1 });
+describe('InputWidget', () => {
+  it('should have 1 output port', () => {
+    const model = new InputModel({ DATA_BITS: 1 });
 
-  const { container } = render(<InputWidget model={model} />);
+    const { container } = render(<InputWidget model={model} />);
 
-  const ports = container.querySelectorAll('[data-name=out]');
-  expect(ports).toHaveLength(1);
-});
-
-it('should have 1 pin when configured with 1-bit', () => {
-  const model = new InputModel({ DATA_BITS: 1 });
-
-  const { getAllByRole } = render(<InputWidget model={model} />);
-
-  const pins = getAllByRole('button');
-  expect(pins).toHaveLength(1);
-});
-
-it('should have 2 pins when configured with 2-bits', () => {
-  const model = new InputModel({ DATA_BITS: 2 });
-
-  const { getAllByRole } = render(<InputWidget model={model} />);
-
-  const pins = getAllByRole('button');
-  expect(pins).toHaveLength(2);
-});
-
-it('should have 4 pins when configured with 4-bits', () => {
-  const model = new InputModel({ DATA_BITS: 4 });
-
-  const { getAllByRole } = render(<InputWidget model={model} />);
-  const pins = getAllByRole('button');
-
-  expect(pins).toHaveLength(4);
-});
-
-it('should have 8 pins when configured with 8-bits', () => {
-  const model = new InputModel({ DATA_BITS: 8 });
-
-  const { getAllByRole } = render(<InputWidget model={model} />);
-  const pins = getAllByRole('button');
-
-  expect(pins).toHaveLength(8);
-});
-
-it('should have 16 pins when configured with 16-bits', () => {
-  const model = new InputModel({ DATA_BITS: 16 });
-
-  const { getAllByRole } = render(<InputWidget model={model} />);
-  const pins = getAllByRole('button');
-
-  expect(pins).toHaveLength(16);
-});
-
-it('should display pin values accordingly', () => {
-  const DATA_BITS = 16;
-
-  const model = new InputModel({ DATA_BITS });
-  const spy = jest.spyOn(model, 'getOutput');
-  spy.mockImplementation(() =>
-    (0b1010_1010_1010_1010).asArray(DATA_BITS),
-  );
-
-  const { getAllByRole } = render(<InputWidget model={model} />);
-  const pins = getAllByRole('button');
-
-  pins.forEach((pin, i) => {
-    expect(pin).toContainHTML(i % 2 ? '0' : '1');
+    const ports = container.querySelectorAll('[data-name=out]');
+    expect(ports).toHaveLength(1);
   });
-});
 
-it('should display floating and errored values correctly', () => {
-  const model = new InputModel({ DATA_BITS: 2 });
-  const spy = jest.spyOn(model, 'getOutput');
-  spy.mockImplementation(() => ['x', 'e']);
+  it('should have 1 pin when configured with 1-bit', () => {
+    const model = new InputModel({ DATA_BITS: 1 });
 
-  const { getAllByRole } = render(<InputWidget model={model} />);
-  const pins = getAllByRole('button');
+    const { getAllByRole } = render(<InputWidget model={model} />);
 
-  pins.forEach((pin, i) => {
-    expect(pin).toContainHTML(i % 2 ? 'e' : 'x');
+    const pins = getAllByRole('button');
+    expect(pins).toHaveLength(1);
   });
-});
 
-it('should call model onClick when a pin is clicked', () => {
-  const model = new InputModel({ DATA_BITS: 16 });
-  const spy = jest.spyOn(model, 'onClick');
-  spy.mockImplementation(() => {});
+  it('should have 2 pins when configured with 2-bits', () => {
+    const model = new InputModel({ DATA_BITS: 2 });
 
-  const { getAllByRole } = render(<InputWidget model={model} />);
-  const pins = getAllByRole('button');
+    const { getAllByRole } = render(<InputWidget model={model} />);
 
-  pins.forEach((pin, i) => {
-    pin.click();
-    expect(spy).toHaveBeenNthCalledWith(i + 1, i);
+    const pins = getAllByRole('button');
+    expect(pins).toHaveLength(2);
+  });
+
+  it('should have 4 pins when configured with 4-bits', () => {
+    const model = new InputModel({ DATA_BITS: 4 });
+
+    const { getAllByRole } = render(<InputWidget model={model} />);
+    const pins = getAllByRole('button');
+
+    expect(pins).toHaveLength(4);
+  });
+
+  it('should have 8 pins when configured with 8-bits', () => {
+    const model = new InputModel({ DATA_BITS: 8 });
+
+    const { getAllByRole } = render(<InputWidget model={model} />);
+    const pins = getAllByRole('button');
+
+    expect(pins).toHaveLength(8);
+  });
+
+  it('should have 16 pins when configured with 16-bits', () => {
+    const model = new InputModel({ DATA_BITS: 16 });
+
+    const { getAllByRole } = render(<InputWidget model={model} />);
+    const pins = getAllByRole('button');
+
+    expect(pins).toHaveLength(16);
+  });
+
+  it('should display pin values accordingly', () => {
+    const DATA_BITS = 16;
+
+    const model = new InputModel({ DATA_BITS });
+    const spy = jest.spyOn(model, 'getOutput');
+    spy.mockImplementation(() =>
+      (0b1010_1010_1010_1010).asArray(DATA_BITS),
+    );
+
+    const { getAllByRole } = render(<InputWidget model={model} />);
+    const pins = getAllByRole('button');
+
+    pins.forEach((pin, i) => {
+      expect(pin).toContainHTML(i % 2 ? '0' : '1');
+    });
+  });
+
+  it('should display floating and errored values correctly', () => {
+    const model = new InputModel({ DATA_BITS: 2 });
+    const spy = jest.spyOn(model, 'getOutput');
+    spy.mockImplementation(() => ['x', 'e']);
+
+    const { getAllByRole } = render(<InputWidget model={model} />);
+    const pins = getAllByRole('button');
+
+    pins.forEach((pin, i) => {
+      expect(pin).toContainHTML(i % 2 ? 'e' : 'x');
+    });
+  });
+
+  it('should call model onClick when a pin is clicked', () => {
+    const model = new InputModel({ DATA_BITS: 16 });
+    const spy = jest.spyOn(model, 'onClick');
+    spy.mockImplementation(() => {});
+
+    const { getAllByRole } = render(<InputWidget model={model} />);
+    const pins = getAllByRole('button');
+
+    pins.forEach((pin, i) => {
+      pin.click();
+      expect(spy).toHaveBeenNthCalledWith(i + 1, i);
+    });
   });
 });

--- a/packages/@logossim/components/Input/__tests__/InputWidget.test.jsx
+++ b/packages/@logossim/components/Input/__tests__/InputWidget.test.jsx
@@ -2,19 +2,14 @@ import React from 'react';
 
 import { convertNumberValueToArray } from '@logossim/core/Simulation/utils';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import InputModel from '../InputModel';
 import InputWidget from '../InputWidget';
-
-const { engine } = global;
 
 it('should have 1 output port', () => {
   const model = new InputModel({ DATA_BITS: 1 });
 
-  const { container } = render(
-    <InputWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<InputWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name=out]');
   expect(ports).toHaveLength(1);
@@ -23,9 +18,7 @@ it('should have 1 output port', () => {
 it('should have 1 pin when configured with 1-bit', () => {
   const model = new InputModel({ DATA_BITS: 1 });
 
-  const { getAllByRole } = render(
-    <InputWidget model={model} engine={engine} />,
-  );
+  const { getAllByRole } = render(<InputWidget model={model} />);
 
   const pins = getAllByRole('button');
   expect(pins).toHaveLength(1);
@@ -34,9 +27,7 @@ it('should have 1 pin when configured with 1-bit', () => {
 it('should have 2 pins when configured with 2-bits', () => {
   const model = new InputModel({ DATA_BITS: 2 });
 
-  const { getAllByRole } = render(
-    <InputWidget model={model} engine={engine} />,
-  );
+  const { getAllByRole } = render(<InputWidget model={model} />);
 
   const pins = getAllByRole('button');
   expect(pins).toHaveLength(2);
@@ -45,9 +36,7 @@ it('should have 2 pins when configured with 2-bits', () => {
 it('should have 4 pins when configured with 4-bits', () => {
   const model = new InputModel({ DATA_BITS: 4 });
 
-  const { getAllByRole } = render(
-    <InputWidget model={model} engine={engine} />,
-  );
+  const { getAllByRole } = render(<InputWidget model={model} />);
   const pins = getAllByRole('button');
 
   expect(pins).toHaveLength(4);
@@ -56,9 +45,7 @@ it('should have 4 pins when configured with 4-bits', () => {
 it('should have 8 pins when configured with 8-bits', () => {
   const model = new InputModel({ DATA_BITS: 8 });
 
-  const { getAllByRole } = render(
-    <InputWidget model={model} engine={engine} />,
-  );
+  const { getAllByRole } = render(<InputWidget model={model} />);
   const pins = getAllByRole('button');
 
   expect(pins).toHaveLength(8);
@@ -67,9 +54,7 @@ it('should have 8 pins when configured with 8-bits', () => {
 it('should have 16 pins when configured with 16-bits', () => {
   const model = new InputModel({ DATA_BITS: 16 });
 
-  const { getAllByRole } = render(
-    <InputWidget model={model} engine={engine} />,
-  );
+  const { getAllByRole } = render(<InputWidget model={model} />);
   const pins = getAllByRole('button');
 
   expect(pins).toHaveLength(16);
@@ -84,9 +69,7 @@ it('should display pin values accordingly', () => {
     convertNumberValueToArray(0b1010_1010_1010_1010, DATA_BITS),
   );
 
-  const { getAllByRole } = render(
-    <InputWidget model={model} engine={engine} />,
-  );
+  const { getAllByRole } = render(<InputWidget model={model} />);
   const pins = getAllByRole('button');
 
   pins.forEach((pin, i) => {
@@ -99,9 +82,7 @@ it('should display floating and errored values correctly', () => {
   const spy = jest.spyOn(model, 'getOutput');
   spy.mockImplementation(() => ['x', 'e']);
 
-  const { getAllByRole } = render(
-    <InputWidget model={model} engine={engine} />,
-  );
+  const { getAllByRole } = render(<InputWidget model={model} />);
   const pins = getAllByRole('button');
 
   pins.forEach((pin, i) => {
@@ -114,9 +95,7 @@ it('should call model onClick when a pin is clicked', () => {
   const spy = jest.spyOn(model, 'onClick');
   spy.mockImplementation(() => {});
 
-  const { getAllByRole } = render(
-    <InputWidget model={model} engine={engine} />,
-  );
+  const { getAllByRole } = render(<InputWidget model={model} />);
   const pins = getAllByRole('button');
 
   pins.forEach((pin, i) => {

--- a/packages/@logossim/components/Joiner/JoinerModel.js
+++ b/packages/@logossim/components/Joiner/JoinerModel.js
@@ -7,7 +7,7 @@ export default class JoinerModel extends BaseModel {
     for (let i = 0; i < this.bits; i += 1) {
       this.addInputPort(`in${i}`);
     }
-    this.addOutputPort('out', this.bits);
+    this.addOutputPort('out', { bits: this.bits });
   }
 
   step(input) {

--- a/packages/@logossim/components/Joiner/JoinerWidget.jsx
+++ b/packages/@logossim/components/Joiner/JoinerWidget.jsx
@@ -53,7 +53,7 @@ export const Shape = ({ selected, dataBits }) => {
 };
 
 const JoinerWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
     configurations: { DATA_BITS },
@@ -69,11 +69,10 @@ const JoinerWidget = props => {
           key={port.getName()}
           name={port.getName()}
           model={model}
-          engine={engine}
           position={i * 15}
         />
       ))}
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} />
       <Shape selected={selected} dataBits={dataBits} />
     </Wrapper>
   );

--- a/packages/@logossim/components/Joiner/JoinerWidget.jsx
+++ b/packages/@logossim/components/Joiner/JoinerWidget.jsx
@@ -68,11 +68,10 @@ const JoinerWidget = props => {
         <PositionedPort
           key={port.getName()}
           name={port.getName()}
-          model={model}
           position={i * 15}
         />
       ))}
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="out" />
       <Shape selected={selected} dataBits={dataBits} />
     </Wrapper>
   );

--- a/packages/@logossim/components/Joiner/JoinerWidget.jsx
+++ b/packages/@logossim/components/Joiner/JoinerWidget.jsx
@@ -69,17 +69,11 @@ const JoinerWidget = props => {
           key={port.getName()}
           name={port.getName()}
           model={model}
-          port={port}
           engine={engine}
           position={i * 15}
         />
       ))}
-      <PositionedPort
-        name="out"
-        model={model}
-        port={model.getPort('out')}
-        engine={engine}
-      />
+      <PositionedPort name="out" model={model} engine={engine} />
       <Shape selected={selected} dataBits={dataBits} />
     </Wrapper>
   );

--- a/packages/@logossim/components/Joiner/__tests__/JoinerModel.test.js
+++ b/packages/@logossim/components/Joiner/__tests__/JoinerModel.test.js
@@ -2,84 +2,86 @@ import JoinerModel from '../JoinerModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const addInputSpy = jest.spyOn(
-    JoinerModel.prototype,
-    'addInputPort',
-  );
-  addInputSpy.mockImplementation(addPort);
+describe('JoinerModel', () => {
+  it('should add ports on initialization', () => {
+    const addInputSpy = jest.spyOn(
+      JoinerModel.prototype,
+      'addInputPort',
+    );
+    addInputSpy.mockImplementation(addPort);
 
-  const addOutputSpy = jest.spyOn(
-    JoinerModel.prototype,
-    'addOutputPort',
-  );
-  addOutputSpy.mockImplementation(addPort);
+    const addOutputSpy = jest.spyOn(
+      JoinerModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  new JoinerModel({
-    DATA_BITS: 16,
+    new JoinerModel({
+      DATA_BITS: 16,
+    });
+
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 16 });
+    [...Array(16).keys()].forEach(i => {
+      expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`);
+    });
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 16 });
-  [...Array(16).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`);
-  });
-});
+  it('should correctly join the input value', () => {
+    const model = new JoinerModel({
+      DATA_BITS: 16,
+    });
 
-it('should correctly join the input value', () => {
-  const model = new JoinerModel({
-    DATA_BITS: 16,
-  });
-
-  expect(
-    model.step({
-      in0: 0,
-      in1: 0,
-      in2: 0,
-      in3: 0,
-      in4: 1,
-      in5: 1,
-      in6: 1,
-      in7: 1,
-      in8: 1,
-      in9: 0,
-      in10: 1,
-      in11: 0,
-      in12: 0,
-      in13: 1,
-      in14: 0,
-      in15: 1,
-    }),
-  ).toEqual({
-    out: 0b1010_0101_1111_0000,
-  });
-});
-
-it('should correctly join input having floating values', () => {
-  const model = new JoinerModel({
-    DATA_BITS: 2,
+    expect(
+      model.step({
+        in0: 0,
+        in1: 0,
+        in2: 0,
+        in3: 0,
+        in4: 1,
+        in5: 1,
+        in6: 1,
+        in7: 1,
+        in8: 1,
+        in9: 0,
+        in10: 1,
+        in11: 0,
+        in12: 0,
+        in13: 1,
+        in14: 0,
+        in15: 1,
+      }),
+    ).toEqual({
+      out: 0b1010_0101_1111_0000,
+    });
   });
 
-  expect(
-    model.stepFloating({
-      in0: ['x'],
-      in1: [0],
-    }),
-  ).toEqual({
-    out: [0, 'x'],
-  });
-});
+  it('should correctly join input having floating values', () => {
+    const model = new JoinerModel({
+      DATA_BITS: 2,
+    });
 
-it('should correctly join input having floating values', () => {
-  const model = new JoinerModel({
-    DATA_BITS: 2,
+    expect(
+      model.stepFloating({
+        in0: ['x'],
+        in1: [0],
+      }),
+    ).toEqual({
+      out: [0, 'x'],
+    });
   });
 
-  expect(
-    model.stepFloating({
-      in0: ['e'],
-      in1: [0],
-    }),
-  ).toEqual({
-    out: [0, 'e'],
+  it('should correctly join input having floating values', () => {
+    const model = new JoinerModel({
+      DATA_BITS: 2,
+    });
+
+    expect(
+      model.stepFloating({
+        in0: ['e'],
+        in1: [0],
+      }),
+    ).toEqual({
+      out: [0, 'e'],
+    });
   });
 });

--- a/packages/@logossim/components/Joiner/__tests__/JoinerModel.test.js
+++ b/packages/@logossim/components/Joiner/__tests__/JoinerModel.test.js
@@ -1,6 +1,3 @@
-/* eslint-disable no-new */
-import { convertNumberValueToArray } from '@logossim/core/Simulation/utils';
-
 import JoinerModel from '../JoinerModel';
 
 const { addPort } = global;
@@ -55,7 +52,7 @@ it('should correctly join the input value', () => {
       in15: 1,
     }),
   ).toEqual({
-    out: convertNumberValueToArray(0b1010_0101_1111_0000, DATA_BITS),
+    out: (0b1010_0101_1111_0000).asArray(DATA_BITS),
   });
 });
 

--- a/packages/@logossim/components/Joiner/__tests__/JoinerModel.test.js
+++ b/packages/@logossim/components/Joiner/__tests__/JoinerModel.test.js
@@ -26,14 +26,12 @@ it('should add ports on initialization', () => {
 });
 
 it('should correctly join the input value', () => {
-  const DATA_BITS = 16;
-
   const model = new JoinerModel({
-    DATA_BITS,
+    DATA_BITS: 16,
   });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 0,
       in1: 0,
       in2: 0,
@@ -52,7 +50,7 @@ it('should correctly join the input value', () => {
       in15: 1,
     }),
   ).toEqual({
-    out: (0b1010_0101_1111_0000).asArray(DATA_BITS),
+    out: 0b1010_0101_1111_0000,
   });
 });
 

--- a/packages/@logossim/components/Joiner/__tests__/JoinerModel.test.js
+++ b/packages/@logossim/components/Joiner/__tests__/JoinerModel.test.js
@@ -22,7 +22,7 @@ it('should add ports on initialization', () => {
     DATA_BITS: 16,
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', 16);
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 16 });
   [...Array(16).keys()].forEach(i => {
     expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`);
   });

--- a/packages/@logossim/components/Joiner/__tests__/JoinerWidget.test.jsx
+++ b/packages/@logossim/components/Joiner/__tests__/JoinerWidget.test.jsx
@@ -1,20 +1,15 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import JoinerModel from '../JoinerModel';
 import JoinerWidget from '../JoinerWidget';
-
-const { engine } = global;
 
 it('should have 1 output port', () => {
   const model = new JoinerModel({
     DATA_BITS: 16,
   });
 
-  const { container } = render(
-    <JoinerWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<JoinerWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name=out]');
   expect(ports).toHaveLength(1);
@@ -25,9 +20,7 @@ it('should have the amount of input ports determined by configuration', () => {
     DATA_BITS: 16,
   });
 
-  const { container } = render(
-    <JoinerWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<JoinerWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name^=in]');
   expect(ports).toHaveLength(16);

--- a/packages/@logossim/components/Joiner/__tests__/JoinerWidget.test.jsx
+++ b/packages/@logossim/components/Joiner/__tests__/JoinerWidget.test.jsx
@@ -4,24 +4,26 @@ import { render } from '../../testUtils';
 import JoinerModel from '../JoinerModel';
 import JoinerWidget from '../JoinerWidget';
 
-it('should have 1 output port', () => {
-  const model = new JoinerModel({
-    DATA_BITS: 16,
+describe('JoinerWidget', () => {
+  it('should have 1 output port', () => {
+    const model = new JoinerModel({
+      DATA_BITS: 16,
+    });
+
+    const { container } = render(<JoinerWidget model={model} />);
+
+    const ports = container.querySelectorAll('[data-name=out]');
+    expect(ports).toHaveLength(1);
   });
 
-  const { container } = render(<JoinerWidget model={model} />);
+  it('should have the amount of input ports determined by configuration', () => {
+    const model = new JoinerModel({
+      DATA_BITS: 16,
+    });
 
-  const ports = container.querySelectorAll('[data-name=out]');
-  expect(ports).toHaveLength(1);
-});
+    const { container } = render(<JoinerWidget model={model} />);
 
-it('should have the amount of input ports determined by configuration', () => {
-  const model = new JoinerModel({
-    DATA_BITS: 16,
+    const ports = container.querySelectorAll('[data-name^=in]');
+    expect(ports).toHaveLength(16);
   });
-
-  const { container } = render(<JoinerWidget model={model} />);
-
-  const ports = container.querySelectorAll('[data-name^=in]');
-  expect(ports).toHaveLength(16);
 });

--- a/packages/@logossim/components/Led/LedModel.js
+++ b/packages/@logossim/components/Led/LedModel.js
@@ -12,11 +12,14 @@ export default class LedModel extends BaseModel {
   }
 
   getInput() {
-    return this.getPort('in').getValue() || [0];
+    const value = this.getPort('in').getValue();
+
+    if (!value) return 0;
+    return value[0];
   }
 
   isActive() {
-    const input = this.getInput()[0];
+    const input = this.getInput();
 
     if (this.activeWhen === 'HIGH') {
       if (input === 0) return false;

--- a/packages/@logossim/components/Led/LedWidget.jsx
+++ b/packages/@logossim/components/Led/LedWidget.jsx
@@ -42,7 +42,7 @@ const LedWidget = props => {
       isActive={model.isActive()}
       data-testid="shape"
     >
-      <PositionedPort name="in" model={model} />
+      <PositionedPort name="in" />
     </Shape>
   );
 };

--- a/packages/@logossim/components/Led/LedWidget.jsx
+++ b/packages/@logossim/components/Led/LedWidget.jsx
@@ -42,12 +42,7 @@ const LedWidget = props => {
       isActive={model.isActive()}
       data-testid="shape"
     >
-      <PositionedPort
-        name="in"
-        model={model}
-        port={model.getPort('in')}
-        engine={engine}
-      />
+      <PositionedPort name="in" model={model} engine={engine} />
     </Shape>
   );
 };

--- a/packages/@logossim/components/Led/LedWidget.jsx
+++ b/packages/@logossim/components/Led/LedWidget.jsx
@@ -30,7 +30,7 @@ export const Shape = styled.div`
 `;
 
 const LedWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
   } = model;
@@ -42,7 +42,7 @@ const LedWidget = props => {
       isActive={model.isActive()}
       data-testid="shape"
     >
-      <PositionedPort name="in" model={model} engine={engine} />
+      <PositionedPort name="in" model={model} />
     </Shape>
   );
 };

--- a/packages/@logossim/components/Led/__tests__/LedModel.test.js
+++ b/packages/@logossim/components/Led/__tests__/LedModel.test.js
@@ -2,11 +2,13 @@ import LedModel from '../LedModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const spy = jest.spyOn(LedModel.prototype, 'addInputPort');
-  spy.mockImplementation(addPort);
+describe('LedModel', () => {
+  it('should add ports on initialization', () => {
+    const spy = jest.spyOn(LedModel.prototype, 'addInputPort');
+    spy.mockImplementation(addPort);
 
-  new LedModel();
+    new LedModel();
 
-  expect(spy).toHaveBeenCalledWith('in');
+    expect(spy).toHaveBeenCalledWith('in');
+  });
 });

--- a/packages/@logossim/components/Led/__tests__/LedModel.test.js
+++ b/packages/@logossim/components/Led/__tests__/LedModel.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import LedModel from '../LedModel';
 
 const { addPort } = global;

--- a/packages/@logossim/components/Led/__tests__/LedWidget.test.jsx
+++ b/packages/@logossim/components/Led/__tests__/LedWidget.test.jsx
@@ -21,7 +21,7 @@ describe('LedWidget', () => {
       OFF_COLOR: '#000000',
     });
     const spy = jest.spyOn(model, 'getInput');
-    spy.mockImplementation(() => [0]);
+    spy.mockImplementation(() => 0);
 
     const { getByTestId } = render(<LedWidget model={model} />);
     const shape = getByTestId('shape');
@@ -36,7 +36,7 @@ describe('LedWidget', () => {
       OFF_COLOR: '#000000',
     });
     const spy = jest.spyOn(model, 'getInput');
-    spy.mockImplementation(() => [1]);
+    spy.mockImplementation(() => 1);
 
     const { getByTestId } = render(<LedWidget model={model} />);
     const shape = getByTestId('shape');
@@ -51,7 +51,7 @@ describe('LedWidget', () => {
       OFF_COLOR: '#000000',
     });
     const spy = jest.spyOn(model, 'getInput');
-    spy.mockImplementation(() => [0]);
+    spy.mockImplementation(() => 0);
 
     const { getByTestId } = render(<LedWidget model={model} />);
     const shape = getByTestId('shape');
@@ -66,7 +66,7 @@ describe('LedWidget', () => {
       OFF_COLOR: '#000000',
     });
     const spy = jest.spyOn(model, 'getInput');
-    spy.mockImplementation(() => [1]);
+    spy.mockImplementation(() => 1);
 
     const { getByTestId } = render(<LedWidget model={model} />);
     const shape = getByTestId('shape');

--- a/packages/@logossim/components/Led/__tests__/LedWidget.test.jsx
+++ b/packages/@logossim/components/Led/__tests__/LedWidget.test.jsx
@@ -1,18 +1,13 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import LedModel from '../LedModel';
 import LedWidget from '../LedWidget';
-
-const { engine } = global;
 
 it('should have 1 input port', () => {
   const model = new LedModel();
 
-  const { container } = render(
-    <LedWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<LedWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name=in]');
   expect(ports).toHaveLength(1);
@@ -27,9 +22,7 @@ it('should display correct color when configured with active on high and value i
   const spy = jest.spyOn(model, 'getInput');
   spy.mockImplementation(() => [0]);
 
-  const { getByTestId } = render(
-    <LedWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<LedWidget model={model} />);
   const shape = getByTestId('shape');
 
   expect(shape).toHaveAttribute('color', '#000000');
@@ -44,9 +37,7 @@ it('should display correct color when configured with active on high and value i
   const spy = jest.spyOn(model, 'getInput');
   spy.mockImplementation(() => [1]);
 
-  const { getByTestId } = render(
-    <LedWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<LedWidget model={model} />);
   const shape = getByTestId('shape');
 
   expect(shape).toHaveAttribute('color', '#ff0000');
@@ -61,9 +52,7 @@ it('should display correct color when configured with active on low and value is
   const spy = jest.spyOn(model, 'getInput');
   spy.mockImplementation(() => [0]);
 
-  const { getByTestId } = render(
-    <LedWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<LedWidget model={model} />);
   const shape = getByTestId('shape');
 
   expect(shape).toHaveAttribute('color', '#ff0000');
@@ -78,9 +67,7 @@ it('should display correct color when configured with active on low and value is
   const spy = jest.spyOn(model, 'getInput');
   spy.mockImplementation(() => [1]);
 
-  const { getByTestId } = render(
-    <LedWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<LedWidget model={model} />);
   const shape = getByTestId('shape');
 
   expect(shape).toHaveAttribute('color', '#000000');

--- a/packages/@logossim/components/Led/__tests__/LedWidget.test.jsx
+++ b/packages/@logossim/components/Led/__tests__/LedWidget.test.jsx
@@ -4,71 +4,73 @@ import { render } from '../../testUtils';
 import LedModel from '../LedModel';
 import LedWidget from '../LedWidget';
 
-it('should have 1 input port', () => {
-  const model = new LedModel();
+describe('LedWidget', () => {
+  it('should have 1 input port', () => {
+    const model = new LedModel();
 
-  const { container } = render(<LedWidget model={model} />);
+    const { container } = render(<LedWidget model={model} />);
 
-  const ports = container.querySelectorAll('[data-name=in]');
-  expect(ports).toHaveLength(1);
-});
-
-it('should display correct color when configured with active on high and value is low', () => {
-  const model = new LedModel({
-    ACTIVE_WHEN: 'HIGH',
-    ON_COLOR: '#ff0000',
-    OFF_COLOR: '#000000',
+    const ports = container.querySelectorAll('[data-name=in]');
+    expect(ports).toHaveLength(1);
   });
-  const spy = jest.spyOn(model, 'getInput');
-  spy.mockImplementation(() => [0]);
 
-  const { getByTestId } = render(<LedWidget model={model} />);
-  const shape = getByTestId('shape');
+  it('should display correct color when configured with active on high and value is low', () => {
+    const model = new LedModel({
+      ACTIVE_WHEN: 'HIGH',
+      ON_COLOR: '#ff0000',
+      OFF_COLOR: '#000000',
+    });
+    const spy = jest.spyOn(model, 'getInput');
+    spy.mockImplementation(() => [0]);
 
-  expect(shape).toHaveAttribute('color', '#000000');
-});
+    const { getByTestId } = render(<LedWidget model={model} />);
+    const shape = getByTestId('shape');
 
-it('should display correct color when configured with active on high and value is high', () => {
-  const model = new LedModel({
-    ACTIVE_WHEN: 'HIGH',
-    ON_COLOR: '#ff0000',
-    OFF_COLOR: '#000000',
+    expect(shape).toHaveAttribute('color', '#000000');
   });
-  const spy = jest.spyOn(model, 'getInput');
-  spy.mockImplementation(() => [1]);
 
-  const { getByTestId } = render(<LedWidget model={model} />);
-  const shape = getByTestId('shape');
+  it('should display correct color when configured with active on high and value is high', () => {
+    const model = new LedModel({
+      ACTIVE_WHEN: 'HIGH',
+      ON_COLOR: '#ff0000',
+      OFF_COLOR: '#000000',
+    });
+    const spy = jest.spyOn(model, 'getInput');
+    spy.mockImplementation(() => [1]);
 
-  expect(shape).toHaveAttribute('color', '#ff0000');
-});
+    const { getByTestId } = render(<LedWidget model={model} />);
+    const shape = getByTestId('shape');
 
-it('should display correct color when configured with active on low and value is low', () => {
-  const model = new LedModel({
-    ACTIVE_WHEN: 'LOW',
-    ON_COLOR: '#ff0000',
-    OFF_COLOR: '#000000',
+    expect(shape).toHaveAttribute('color', '#ff0000');
   });
-  const spy = jest.spyOn(model, 'getInput');
-  spy.mockImplementation(() => [0]);
 
-  const { getByTestId } = render(<LedWidget model={model} />);
-  const shape = getByTestId('shape');
+  it('should display correct color when configured with active on low and value is low', () => {
+    const model = new LedModel({
+      ACTIVE_WHEN: 'LOW',
+      ON_COLOR: '#ff0000',
+      OFF_COLOR: '#000000',
+    });
+    const spy = jest.spyOn(model, 'getInput');
+    spy.mockImplementation(() => [0]);
 
-  expect(shape).toHaveAttribute('color', '#ff0000');
-});
+    const { getByTestId } = render(<LedWidget model={model} />);
+    const shape = getByTestId('shape');
 
-it('should display correct color when configured with active on low and value is high', () => {
-  const model = new LedModel({
-    ACTIVE_WHEN: 'LOW',
-    ON_COLOR: '#ff0000',
-    OFF_COLOR: '#000000',
+    expect(shape).toHaveAttribute('color', '#ff0000');
   });
-  const spy = jest.spyOn(model, 'getInput');
-  spy.mockImplementation(() => [1]);
 
-  const { getByTestId } = render(<LedWidget model={model} />);
-  const shape = getByTestId('shape');
+  it('should display correct color when configured with active on low and value is high', () => {
+    const model = new LedModel({
+      ACTIVE_WHEN: 'LOW',
+      ON_COLOR: '#ff0000',
+      OFF_COLOR: '#000000',
+    });
+    const spy = jest.spyOn(model, 'getInput');
+    spy.mockImplementation(() => [1]);
 
-  expect(shape).toHaveAttribute('color', '#000000');
+    const { getByTestId } = render(<LedWidget model={model} />);
+    const shape = getByTestId('shape');
+
+    expect(shape).toHaveAttribute('color', '#000000');
+  });
 });

--- a/packages/@logossim/components/Mux/MuxModel.js
+++ b/packages/@logossim/components/Mux/MuxModel.js
@@ -6,11 +6,11 @@ export default class MuxModel extends BaseModel {
     const INPUT_NUMBER = Number(configurations.INPUT_NUMBER);
 
     for (let i = 0; i < INPUT_NUMBER; i += 1) {
-      this.addInputPort(`in${i}`, DATA_BITS);
+      this.addInputPort(`in${i}`, { bits: DATA_BITS });
     }
 
-    this.addInputPort('selection', Math.log2(INPUT_NUMBER));
-    this.addOutputPort('out', DATA_BITS);
+    this.addInputPort('selection', { bits: Math.log2(INPUT_NUMBER) });
+    this.addOutputPort('out', { bits: DATA_BITS });
   }
 
   step(input) {

--- a/packages/@logossim/components/Mux/MuxWidget.jsx
+++ b/packages/@logossim/components/Mux/MuxWidget.jsx
@@ -48,7 +48,7 @@ export const Shape = ({ selected, inputNumber, icon }) => {
 };
 
 const MuxWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
   } = model;
@@ -63,14 +63,12 @@ const MuxWidget = props => {
           key={port.getName()}
           name={port.getName()}
           model={model}
-          engine={engine}
           position={(i + 1) * 15}
         />
       ))}
       <PositionedPort
         name="out"
         model={model}
-        engine={engine}
         position={((inputNumber + 1) * 15) / 2}
       />
       <Shape selected={selected} inputNumber={inputNumber} />

--- a/packages/@logossim/components/Mux/MuxWidget.jsx
+++ b/packages/@logossim/components/Mux/MuxWidget.jsx
@@ -63,7 +63,6 @@ const MuxWidget = props => {
           key={port.getName()}
           name={port.getName()}
           model={model}
-          port={port}
           engine={engine}
           position={(i + 1) * 15}
         />
@@ -71,7 +70,6 @@ const MuxWidget = props => {
       <PositionedPort
         name="out"
         model={model}
-        port={model.getPort('out')}
         engine={engine}
         position={((inputNumber + 1) * 15) / 2}
       />

--- a/packages/@logossim/components/Mux/MuxWidget.jsx
+++ b/packages/@logossim/components/Mux/MuxWidget.jsx
@@ -62,13 +62,11 @@ const MuxWidget = props => {
         <PositionedPort
           key={port.getName()}
           name={port.getName()}
-          model={model}
           position={(i + 1) * 15}
         />
       ))}
       <PositionedPort
         name="out"
-        model={model}
         position={((inputNumber + 1) * 15) / 2}
       />
       <Shape selected={selected} inputNumber={inputNumber} />

--- a/packages/@logossim/components/Mux/__tests__/MuxModel.test.js
+++ b/packages/@logossim/components/Mux/__tests__/MuxModel.test.js
@@ -1,6 +1,3 @@
-/* eslint-disable no-new */
-import { convertNumberValueToArray } from '@logossim/core/Simulation/utils';
-
 import MuxModel from '../MuxModel';
 
 const { addPort } = global;
@@ -80,7 +77,7 @@ it('should correctly select the input based on selection value', () => {
         in15: 0b1111,
       }),
     ).toEqual({
-      out: convertNumberValueToArray(i, DATA_BITS),
+      out: i.asArray(DATA_BITS),
     });
   });
 });

--- a/packages/@logossim/components/Mux/__tests__/MuxModel.test.js
+++ b/packages/@logossim/components/Mux/__tests__/MuxModel.test.js
@@ -17,10 +17,10 @@ it('should add ports on initialization (2 inputs)', () => {
     INPUT_NUMBER: 2,
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', 1);
-  expect(addInputSpy).toHaveBeenCalledWith('selection', 1);
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
+  expect(addInputSpy).toHaveBeenCalledWith('selection', { bits: 1 });
   [...Array(2).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenCalledWith(`in${i}`, 1);
+    expect(addInputSpy).toHaveBeenCalledWith(`in${i}`, { bits: 1 });
   });
 });
 
@@ -30,10 +30,10 @@ it('should add ports on initialization (4 inputs)', () => {
     INPUT_NUMBER: 4,
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', 8);
-  expect(addInputSpy).toHaveBeenCalledWith('selection', 2);
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 8 });
+  expect(addInputSpy).toHaveBeenCalledWith('selection', { bits: 2 });
   [...Array(4).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenCalledWith(`in${i}`, 8);
+    expect(addInputSpy).toHaveBeenCalledWith(`in${i}`, { bits: 8 });
   });
 });
 
@@ -43,10 +43,10 @@ it('should add ports on initialization (16 inputs)', () => {
     INPUT_NUMBER: 16,
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', 4);
-  expect(addInputSpy).toHaveBeenCalledWith('selection', 4);
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
+  expect(addInputSpy).toHaveBeenCalledWith('selection', { bits: 4 });
   [...Array(16).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenCalledWith(`in${i}`, 4);
+    expect(addInputSpy).toHaveBeenCalledWith(`in${i}`, { bits: 4 });
   });
 });
 

--- a/packages/@logossim/components/Mux/__tests__/MuxModel.test.js
+++ b/packages/@logossim/components/Mux/__tests__/MuxModel.test.js
@@ -8,74 +8,82 @@ addInputSpy.mockImplementation(addPort);
 const addOutputSpy = jest.spyOn(MuxModel.prototype, 'addOutputPort');
 addOutputSpy.mockImplementation(addPort);
 
-it('should add ports on initialization (2 inputs)', () => {
-  new MuxModel({
-    DATA_BITS: 1,
-    INPUT_NUMBER: 2,
+describe('MuxModel', () => {
+  it('should add ports on initialization (2 inputs)', () => {
+    new MuxModel({
+      DATA_BITS: 1,
+      INPUT_NUMBER: 2,
+    });
+
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
+    expect(addInputSpy).toHaveBeenCalledWith('selection', {
+      bits: 1,
+    });
+    [...Array(2).keys()].forEach(i => {
+      expect(addInputSpy).toHaveBeenCalledWith(`in${i}`, { bits: 1 });
+    });
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
-  expect(addInputSpy).toHaveBeenCalledWith('selection', { bits: 1 });
-  [...Array(2).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenCalledWith(`in${i}`, { bits: 1 });
-  });
-});
+  it('should add ports on initialization (4 inputs)', () => {
+    new MuxModel({
+      DATA_BITS: 8,
+      INPUT_NUMBER: 4,
+    });
 
-it('should add ports on initialization (4 inputs)', () => {
-  new MuxModel({
-    DATA_BITS: 8,
-    INPUT_NUMBER: 4,
-  });
-
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 8 });
-  expect(addInputSpy).toHaveBeenCalledWith('selection', { bits: 2 });
-  [...Array(4).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenCalledWith(`in${i}`, { bits: 8 });
-  });
-});
-
-it('should add ports on initialization (16 inputs)', () => {
-  new MuxModel({
-    DATA_BITS: 4,
-    INPUT_NUMBER: 16,
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 8 });
+    expect(addInputSpy).toHaveBeenCalledWith('selection', {
+      bits: 2,
+    });
+    [...Array(4).keys()].forEach(i => {
+      expect(addInputSpy).toHaveBeenCalledWith(`in${i}`, { bits: 8 });
+    });
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
-  expect(addInputSpy).toHaveBeenCalledWith('selection', { bits: 4 });
-  [...Array(16).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenCalledWith(`in${i}`, { bits: 4 });
-  });
-});
+  it('should add ports on initialization (16 inputs)', () => {
+    new MuxModel({
+      DATA_BITS: 4,
+      INPUT_NUMBER: 16,
+    });
 
-it('should correctly select the input based on selection value', () => {
-  const model = new MuxModel({
-    DATA_BITS: 4,
-    INPUT_NUMBER: 16,
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
+    expect(addInputSpy).toHaveBeenCalledWith('selection', {
+      bits: 4,
+    });
+    [...Array(16).keys()].forEach(i => {
+      expect(addInputSpy).toHaveBeenCalledWith(`in${i}`, { bits: 4 });
+    });
   });
 
-  [...Array(16).keys()].forEach(i => {
-    expect(
-      model.step({
-        selection: i,
-        in0: 0b0000,
-        in1: 0b0001,
-        in2: 0b0010,
-        in3: 0b0011,
-        in4: 0b0100,
-        in5: 0b0101,
-        in6: 0b0110,
-        in7: 0b0111,
-        in8: 0b1000,
-        in9: 0b1001,
-        in10: 0b1010,
-        in11: 0b1011,
-        in12: 0b1100,
-        in13: 0b1101,
-        in14: 0b1110,
-        in15: 0b1111,
-      }),
-    ).toEqual({
-      out: i,
+  it('should correctly select the input based on selection value', () => {
+    const model = new MuxModel({
+      DATA_BITS: 4,
+      INPUT_NUMBER: 16,
+    });
+
+    [...Array(16).keys()].forEach(i => {
+      expect(
+        model.step({
+          selection: i,
+          in0: 0b0000,
+          in1: 0b0001,
+          in2: 0b0010,
+          in3: 0b0011,
+          in4: 0b0100,
+          in5: 0b0101,
+          in6: 0b0110,
+          in7: 0b0111,
+          in8: 0b1000,
+          in9: 0b1001,
+          in10: 0b1010,
+          in11: 0b1011,
+          in12: 0b1100,
+          in13: 0b1101,
+          in14: 0b1110,
+          in15: 0b1111,
+        }),
+      ).toEqual({
+        out: i,
+      });
     });
   });
 });

--- a/packages/@logossim/components/Mux/__tests__/MuxModel.test.js
+++ b/packages/@logossim/components/Mux/__tests__/MuxModel.test.js
@@ -48,16 +48,14 @@ it('should add ports on initialization (16 inputs)', () => {
 });
 
 it('should correctly select the input based on selection value', () => {
-  const DATA_BITS = 4;
-
   const model = new MuxModel({
-    DATA_BITS,
+    DATA_BITS: 4,
     INPUT_NUMBER: 16,
   });
 
   [...Array(16).keys()].forEach(i => {
     expect(
-      model.stepAndMask({
+      model.step({
         selection: i,
         in0: 0b0000,
         in1: 0b0001,
@@ -77,7 +75,7 @@ it('should correctly select the input based on selection value', () => {
         in15: 0b1111,
       }),
     ).toEqual({
-      out: i.asArray(DATA_BITS),
+      out: i,
     });
   });
 });

--- a/packages/@logossim/components/Mux/__tests__/MuxWidget.test.jsx
+++ b/packages/@logossim/components/Mux/__tests__/MuxWidget.test.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import MuxModel from '../MuxModel';
 import MuxWidget from '../MuxWidget';
-
-const { engine } = global;
 
 it('should have 1 selection and 1 output port', () => {
   const model = new MuxModel({
@@ -13,9 +10,7 @@ it('should have 1 selection and 1 output port', () => {
     INPUT_NUMBER: 16,
   });
 
-  const { container } = render(
-    <MuxWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<MuxWidget model={model} />);
 
   const selection = container.querySelector('[data-name=selection]');
   const output = container.querySelector('[data-name=out]');
@@ -30,9 +25,7 @@ it('should have the amount of input ports determined by configuration', () => {
     INPUT_NUMBER: 4,
   });
 
-  const { container } = render(
-    <MuxWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<MuxWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name^=in]');
   expect(ports).toHaveLength(4);

--- a/packages/@logossim/components/Mux/__tests__/MuxWidget.test.jsx
+++ b/packages/@logossim/components/Mux/__tests__/MuxWidget.test.jsx
@@ -4,29 +4,33 @@ import { render } from '../../testUtils';
 import MuxModel from '../MuxModel';
 import MuxWidget from '../MuxWidget';
 
-it('should have 1 selection and 1 output port', () => {
-  const model = new MuxModel({
-    DATA_BITS: 1,
-    INPUT_NUMBER: 16,
+describe('MuxWidget', () => {
+  it('should have 1 selection and 1 output port', () => {
+    const model = new MuxModel({
+      DATA_BITS: 1,
+      INPUT_NUMBER: 16,
+    });
+
+    const { container } = render(<MuxWidget model={model} />);
+
+    const selection = container.querySelector(
+      '[data-name=selection]',
+    );
+    const output = container.querySelector('[data-name=out]');
+
+    expect(selection).toBeTruthy();
+    expect(output).toBeTruthy();
   });
 
-  const { container } = render(<MuxWidget model={model} />);
+  it('should have the amount of input ports determined by configuration', () => {
+    const model = new MuxModel({
+      DATA_BITS: 16,
+      INPUT_NUMBER: 4,
+    });
 
-  const selection = container.querySelector('[data-name=selection]');
-  const output = container.querySelector('[data-name=out]');
+    const { container } = render(<MuxWidget model={model} />);
 
-  expect(selection).toBeTruthy();
-  expect(output).toBeTruthy();
-});
-
-it('should have the amount of input ports determined by configuration', () => {
-  const model = new MuxModel({
-    DATA_BITS: 16,
-    INPUT_NUMBER: 4,
+    const ports = container.querySelectorAll('[data-name^=in]');
+    expect(ports).toHaveLength(4);
   });
-
-  const { container } = render(<MuxWidget model={model} />);
-
-  const ports = container.querySelectorAll('[data-name^=in]');
-  expect(ports).toHaveLength(4);
 });

--- a/packages/@logossim/components/Nand/NandModel.js
+++ b/packages/@logossim/components/Nand/NandModel.js
@@ -5,17 +5,34 @@ export default class NandModel extends BaseModel {
     const INPUT_PORTS_NUMBER = Number(
       configurations.INPUT_PORTS_NUMBER,
     );
-    const DATA_BITS = Number(configurations.DATA_BITS);
+    this.dataBits = Number(configurations.DATA_BITS);
 
     for (let i = 0; i < INPUT_PORTS_NUMBER; i += 1) {
-      this.addInputPort(`in${i}`, { bits: DATA_BITS });
+      this.addInputPort(`in${i}`, { bits: this.dataBits });
     }
-    this.addOutputPort('out', { bits: DATA_BITS });
+    this.addOutputPort('out', { bits: this.dataBits });
+  }
+
+  executeBit(bits) {
+    if (bits.some(bit => bit === 0)) return 1;
+    if (bits.every(bit => bit === 1)) return 0;
+    return 'e';
   }
 
   step(input) {
     return {
-      out: ~Object.values(input).reduce((acc, curr) => acc & curr),
+      out: Object.values(input)
+        .map(value => value.asArray(this.dataBits))
+        .transpose()
+        .map(this.executeBit),
     };
+  }
+
+  stepFloating(input) {
+    return this.step(input);
+  }
+
+  stepError(input) {
+    return this.step(input);
   }
 }

--- a/packages/@logossim/components/Nand/NandModel.js
+++ b/packages/@logossim/components/Nand/NandModel.js
@@ -8,9 +8,9 @@ export default class NandModel extends BaseModel {
     const DATA_BITS = Number(configurations.DATA_BITS);
 
     for (let i = 0; i < INPUT_PORTS_NUMBER; i += 1) {
-      this.addInputPort(`in${i}`, DATA_BITS);
+      this.addInputPort(`in${i}`, { bits: DATA_BITS });
     }
-    this.addOutputPort('out', DATA_BITS);
+    this.addOutputPort('out', { bits: DATA_BITS });
   }
 
   step(input) {

--- a/packages/@logossim/components/Nand/NandWidget.jsx
+++ b/packages/@logossim/components/Nand/NandWidget.jsx
@@ -75,17 +75,11 @@ const NandWidget = props => {
           key={port.getName()}
           name={port.getName()}
           model={model}
-          port={port}
           engine={engine}
           position={portPositions[i]}
         />
       ))}
-      <PositionedPort
-        name="out"
-        model={model}
-        port={model.getPort('out')}
-        engine={engine}
-      />
+      <PositionedPort name="out" model={model} engine={engine} />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/Nand/NandWidget.jsx
+++ b/packages/@logossim/components/Nand/NandWidget.jsx
@@ -59,7 +59,7 @@ export const Shape = ({ size = 90 }) => (
 );
 
 const NandWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
 
   const inputPorts = Object.values(model.getInputPorts());
   const portPositions = distributePorts(inputPorts.length);
@@ -75,11 +75,10 @@ const NandWidget = props => {
           key={port.getName()}
           name={port.getName()}
           model={model}
-          engine={engine}
           position={portPositions[i]}
         />
       ))}
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/Nand/NandWidget.jsx
+++ b/packages/@logossim/components/Nand/NandWidget.jsx
@@ -74,11 +74,10 @@ const NandWidget = props => {
         <PositionedPort
           key={port.getName()}
           name={port.getName()}
-          model={model}
           position={portPositions[i]}
         />
       ))}
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="out" />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/Nand/__tests__/NandModel.test.js
+++ b/packages/@logossim/components/Nand/__tests__/NandModel.test.js
@@ -20,9 +20,11 @@ it('should add ports on initialization', () => {
     DATA_BITS: 1,
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', 1);
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
   [...Array(16).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, 1);
+    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
+      bits: 1,
+    });
   });
 });
 

--- a/packages/@logossim/components/Nand/__tests__/NandModel.test.js
+++ b/packages/@logossim/components/Nand/__tests__/NandModel.test.js
@@ -1,6 +1,3 @@
-/* eslint-disable no-new */
-import { convertNumberValueToArray } from '@logossim/core/Simulation/utils';
-
 import NandModel from '../NandModel';
 
 const { addPort } = global;
@@ -75,5 +72,5 @@ it('should return bitwise NAND for multiple data bits', () => {
       in2: 0b0101,
       in3: 0b1001,
     }),
-  ).toEqual({ out: convertNumberValueToArray(0b1110, DATA_BITS) });
+  ).toEqual({ out: (0b1110).asArray(DATA_BITS) });
 });

--- a/packages/@logossim/components/Nand/__tests__/NandModel.test.js
+++ b/packages/@logossim/components/Nand/__tests__/NandModel.test.js
@@ -32,11 +32,11 @@ it("should return 1 when there's a 0 input", () => {
   });
 
   expect(
-    model.stepAndMask({
-      in0: 0,
+    model.step({
+      in0: 1,
       in1: 0,
-      in2: 0,
-      in3: 0,
+      in2: 1,
+      in3: 1,
     }),
   ).toEqual({ out: [1] });
 });
@@ -48,13 +48,41 @@ it('should return 0 when all inputs are 1', () => {
   });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 1,
       in1: 1,
       in2: 1,
       in3: 1,
     }),
   ).toEqual({ out: [0] });
+});
+
+it("should return error when there's no 0 and there's one floating input", () => {
+  const model = new NandModel({
+    INPUT_PORTS_NUMBER: 2,
+    DATA_BITS: 1,
+  });
+
+  expect(
+    model.stepFloating({
+      in0: [1],
+      in1: ['x'],
+    }),
+  ).toEqual({ out: ['e'] });
+});
+
+it("should return error when there's no 0 and there's one error input", () => {
+  const model = new NandModel({
+    INPUT_PORTS_NUMBER: 2,
+    DATA_BITS: 1,
+  });
+
+  expect(
+    model.stepError({
+      in0: [1],
+      in1: ['e'],
+    }),
+  ).toEqual({ out: ['e'] });
 });
 
 it('should return bitwise NAND for multiple data bits', () => {
@@ -66,7 +94,7 @@ it('should return bitwise NAND for multiple data bits', () => {
   });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 0b0001,
       in1: 0b0011,
       in2: 0b0101,

--- a/packages/@logossim/components/Nand/__tests__/NandModel.test.js
+++ b/packages/@logossim/components/Nand/__tests__/NandModel.test.js
@@ -2,103 +2,108 @@ import NandModel from '../NandModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const addInputSpy = jest.spyOn(NandModel.prototype, 'addInputPort');
-  addInputSpy.mockImplementation(addPort);
+describe('NandModel', () => {
+  it('should add ports on initialization', () => {
+    const addInputSpy = jest.spyOn(
+      NandModel.prototype,
+      'addInputPort',
+    );
+    addInputSpy.mockImplementation(addPort);
 
-  const addOutputSpy = jest.spyOn(
-    NandModel.prototype,
-    'addOutputPort',
-  );
-  addOutputSpy.mockImplementation(addPort);
+    const addOutputSpy = jest.spyOn(
+      NandModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  new NandModel({
-    INPUT_PORTS_NUMBER: 16,
-    DATA_BITS: 1,
-  });
+    new NandModel({
+      INPUT_PORTS_NUMBER: 16,
+      DATA_BITS: 1,
+    });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
-  [...Array(16).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
-      bits: 1,
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
+    [...Array(16).keys()].forEach(i => {
+      expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
+        bits: 1,
+      });
     });
   });
-});
 
-it("should return 1 when there's a 0 input", () => {
-  const model = new NandModel({
-    INPUT_PORTS_NUMBER: 4,
-    DATA_BITS: 1,
+  it("should return 1 when there's a 0 input", () => {
+    const model = new NandModel({
+      INPUT_PORTS_NUMBER: 4,
+      DATA_BITS: 1,
+    });
+
+    expect(
+      model.step({
+        in0: 1,
+        in1: 0,
+        in2: 1,
+        in3: 1,
+      }),
+    ).toEqual({ out: [1] });
   });
 
-  expect(
-    model.step({
-      in0: 1,
-      in1: 0,
-      in2: 1,
-      in3: 1,
-    }),
-  ).toEqual({ out: [1] });
-});
+  it('should return 0 when all inputs are 1', () => {
+    const model = new NandModel({
+      INPUT_PORTS_NUMBER: 4,
+      DATA_BITS: 1,
+    });
 
-it('should return 0 when all inputs are 1', () => {
-  const model = new NandModel({
-    INPUT_PORTS_NUMBER: 4,
-    DATA_BITS: 1,
+    expect(
+      model.step({
+        in0: 1,
+        in1: 1,
+        in2: 1,
+        in3: 1,
+      }),
+    ).toEqual({ out: [0] });
   });
 
-  expect(
-    model.step({
-      in0: 1,
-      in1: 1,
-      in2: 1,
-      in3: 1,
-    }),
-  ).toEqual({ out: [0] });
-});
+  it("should return error when there's no 0 and there's one floating input", () => {
+    const model = new NandModel({
+      INPUT_PORTS_NUMBER: 2,
+      DATA_BITS: 1,
+    });
 
-it("should return error when there's no 0 and there's one floating input", () => {
-  const model = new NandModel({
-    INPUT_PORTS_NUMBER: 2,
-    DATA_BITS: 1,
+    expect(
+      model.stepFloating({
+        in0: [1],
+        in1: ['x'],
+      }),
+    ).toEqual({ out: ['e'] });
   });
 
-  expect(
-    model.stepFloating({
-      in0: [1],
-      in1: ['x'],
-    }),
-  ).toEqual({ out: ['e'] });
-});
+  it("should return error when there's no 0 and there's one error input", () => {
+    const model = new NandModel({
+      INPUT_PORTS_NUMBER: 2,
+      DATA_BITS: 1,
+    });
 
-it("should return error when there's no 0 and there's one error input", () => {
-  const model = new NandModel({
-    INPUT_PORTS_NUMBER: 2,
-    DATA_BITS: 1,
+    expect(
+      model.stepError({
+        in0: [1],
+        in1: ['e'],
+      }),
+    ).toEqual({ out: ['e'] });
   });
 
-  expect(
-    model.stepError({
-      in0: [1],
-      in1: ['e'],
-    }),
-  ).toEqual({ out: ['e'] });
-});
+  it('should return bitwise NAND for multiple data bits', () => {
+    const DATA_BITS = 4;
 
-it('should return bitwise NAND for multiple data bits', () => {
-  const DATA_BITS = 4;
+    const model = new NandModel({
+      INPUT_PORTS_NUMBER: 4,
+      DATA_BITS,
+    });
 
-  const model = new NandModel({
-    INPUT_PORTS_NUMBER: 4,
-    DATA_BITS,
+    expect(
+      model.step({
+        in0: 0b0001,
+        in1: 0b0011,
+        in2: 0b0101,
+        in3: 0b1001,
+      }),
+    ).toEqual({ out: (0b1110).asArray(DATA_BITS) });
   });
-
-  expect(
-    model.step({
-      in0: 0b0001,
-      in1: 0b0011,
-      in2: 0b0101,
-      in3: 0b1001,
-    }),
-  ).toEqual({ out: (0b1110).asArray(DATA_BITS) });
 });

--- a/packages/@logossim/components/Nand/__tests__/NandWidget.test.jsx
+++ b/packages/@logossim/components/Nand/__tests__/NandWidget.test.jsx
@@ -4,25 +4,27 @@ import { render } from '../../testUtils';
 import NandModel from '../NandModel';
 import NandWidget from '../NandWidget';
 
-it('should have 1 output port', () => {
-  const model = new NandModel({
-    DATA_BITS: 1,
+describe('NandWidget', () => {
+  it('should have 1 output port', () => {
+    const model = new NandModel({
+      DATA_BITS: 1,
+    });
+
+    const { container } = render(<NandWidget model={model} />);
+
+    const ports = container.querySelectorAll('[data-name=out]');
+    expect(ports).toHaveLength(1);
   });
 
-  const { container } = render(<NandWidget model={model} />);
+  it('should have the amount of input ports determined by configuration', () => {
+    const model = new NandModel({
+      INPUT_PORTS_NUMBER: 16,
+      DATA_BITS: 1,
+    });
 
-  const ports = container.querySelectorAll('[data-name=out]');
-  expect(ports).toHaveLength(1);
-});
+    const { container } = render(<NandWidget model={model} />);
 
-it('should have the amount of input ports determined by configuration', () => {
-  const model = new NandModel({
-    INPUT_PORTS_NUMBER: 16,
-    DATA_BITS: 1,
+    const ports = container.querySelectorAll('[data-name^=in]');
+    expect(ports).toHaveLength(16);
   });
-
-  const { container } = render(<NandWidget model={model} />);
-
-  const ports = container.querySelectorAll('[data-name^=in]');
-  expect(ports).toHaveLength(16);
 });

--- a/packages/@logossim/components/Nand/__tests__/NandWidget.test.jsx
+++ b/packages/@logossim/components/Nand/__tests__/NandWidget.test.jsx
@@ -1,20 +1,15 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import NandModel from '../NandModel';
 import NandWidget from '../NandWidget';
-
-const { engine } = global;
 
 it('should have 1 output port', () => {
   const model = new NandModel({
     DATA_BITS: 1,
   });
 
-  const { container } = render(
-    <NandWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<NandWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name=out]');
   expect(ports).toHaveLength(1);
@@ -26,9 +21,7 @@ it('should have the amount of input ports determined by configuration', () => {
     DATA_BITS: 1,
   });
 
-  const { container } = render(
-    <NandWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<NandWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name^=in]');
   expect(ports).toHaveLength(16);

--- a/packages/@logossim/components/Nor/NorModel.js
+++ b/packages/@logossim/components/Nor/NorModel.js
@@ -8,9 +8,9 @@ export default class NorModel extends BaseModel {
     const DATA_BITS = Number(configurations.DATA_BITS);
 
     for (let i = 0; i < INPUT_PORTS_NUMBER; i += 1) {
-      this.addInputPort(`in${i}`, DATA_BITS);
+      this.addInputPort(`in${i}`, { bits: DATA_BITS });
     }
-    this.addOutputPort('out', DATA_BITS);
+    this.addOutputPort('out', { bits: DATA_BITS });
   }
 
   step(input) {

--- a/packages/@logossim/components/Nor/NorModel.js
+++ b/packages/@logossim/components/Nor/NorModel.js
@@ -5,17 +5,34 @@ export default class NorModel extends BaseModel {
     const INPUT_PORTS_NUMBER = Number(
       configurations.INPUT_PORTS_NUMBER,
     );
-    const DATA_BITS = Number(configurations.DATA_BITS);
+    this.dataBits = Number(configurations.DATA_BITS);
 
     for (let i = 0; i < INPUT_PORTS_NUMBER; i += 1) {
-      this.addInputPort(`in${i}`, { bits: DATA_BITS });
+      this.addInputPort(`in${i}`, { bits: this.dataBits });
     }
-    this.addOutputPort('out', { bits: DATA_BITS });
+    this.addOutputPort('out', { bits: this.dataBits });
+  }
+
+  executeBit(bits) {
+    if (bits.every(bit => bit === 0)) return 1;
+    if (bits.some(bit => bit === 1)) return 0;
+    return 'e';
   }
 
   step(input) {
     return {
-      out: ~Object.values(input).reduce((acc, curr) => acc | curr),
+      out: Object.values(input)
+        .map(value => value.asArray(this.dataBits))
+        .transpose()
+        .map(this.executeBit),
     };
+  }
+
+  stepFloating(input) {
+    return this.step(input);
+  }
+
+  stepError(input) {
+    return this.step(input);
   }
 }

--- a/packages/@logossim/components/Nor/NorWidget.jsx
+++ b/packages/@logossim/components/Nor/NorWidget.jsx
@@ -108,7 +108,6 @@ const NorWidget = props => {
         <Fragment key={port.getName()}>
           <PositionedPort
             name={port.getName()}
-            model={model}
             position={portPositions[i]}
           />
           {(portPositions[i] < 1 || portPositions[i] > 5) && (
@@ -119,7 +118,7 @@ const NorWidget = props => {
           )}
         </Fragment>
       ))}
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="out" />
       <Shape portPositions={portPositions} />
     </Wrapper>
   );

--- a/packages/@logossim/components/Nor/NorWidget.jsx
+++ b/packages/@logossim/components/Nor/NorWidget.jsx
@@ -92,7 +92,7 @@ export const Shape = ({ size = 90, portPositions = [] }) => (
 );
 
 const NorWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
 
   const inputPorts = Object.values(model.getInputPorts());
   const portPositions = distributePorts(inputPorts.length);
@@ -109,7 +109,6 @@ const NorWidget = props => {
           <PositionedPort
             name={port.getName()}
             model={model}
-            engine={engine}
             position={portPositions[i]}
           />
           {(portPositions[i] < 1 || portPositions[i] > 5) && (
@@ -120,7 +119,7 @@ const NorWidget = props => {
           )}
         </Fragment>
       ))}
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} />
       <Shape portPositions={portPositions} />
     </Wrapper>
   );

--- a/packages/@logossim/components/Nor/NorWidget.jsx
+++ b/packages/@logossim/components/Nor/NorWidget.jsx
@@ -109,7 +109,6 @@ const NorWidget = props => {
           <PositionedPort
             name={port.getName()}
             model={model}
-            port={port}
             engine={engine}
             position={portPositions[i]}
           />
@@ -121,12 +120,7 @@ const NorWidget = props => {
           )}
         </Fragment>
       ))}
-      <PositionedPort
-        name="out"
-        model={model}
-        port={model.getPort('out')}
-        engine={engine}
-      />
+      <PositionedPort name="out" model={model} engine={engine} />
       <Shape portPositions={portPositions} />
     </Wrapper>
   );

--- a/packages/@logossim/components/Nor/__tests__/NorModel.test.js
+++ b/packages/@logossim/components/Nor/__tests__/NorModel.test.js
@@ -1,6 +1,3 @@
-/* eslint-disable no-new */
-import { convertNumberValueToArray } from '@logossim/core/Simulation/utils';
-
 import NorModel from '../NorModel';
 
 const { addPort } = global;
@@ -112,6 +109,6 @@ it('should return bitwise NOR for multiple data bits', () => {
       in3: 0b0101_0101,
     }),
   ).toEqual({
-    out: convertNumberValueToArray(0b1000_0000, DATA_BITS),
+    out: (0b1000_0000).asArray(DATA_BITS),
   });
 });

--- a/packages/@logossim/components/Nor/__tests__/NorModel.test.js
+++ b/packages/@logossim/components/Nor/__tests__/NorModel.test.js
@@ -20,9 +20,11 @@ it('should add ports on initialization', () => {
     DATA_BITS: 1,
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', 1);
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
   [...Array(16).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, 1);
+    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
+      bits: 1,
+    });
   });
 });
 

--- a/packages/@logossim/components/Nor/__tests__/NorModel.test.js
+++ b/packages/@logossim/components/Nor/__tests__/NorModel.test.js
@@ -32,7 +32,7 @@ it("should return 0 when there's a 1 input", () => {
   });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 1,
       in1: 0,
       in2: 0,
@@ -41,7 +41,7 @@ it("should return 0 when there's a 1 input", () => {
   ).toEqual({ out: [0] });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 0,
       in1: 1,
       in2: 0,
@@ -50,7 +50,7 @@ it("should return 0 when there's a 1 input", () => {
   ).toEqual({ out: [0] });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 0,
       in1: 0,
       in2: 1,
@@ -59,7 +59,7 @@ it("should return 0 when there's a 1 input", () => {
   ).toEqual({ out: [0] });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 0,
       in1: 0,
       in2: 0,
@@ -68,7 +68,7 @@ it("should return 0 when there's a 1 input", () => {
   ).toEqual({ out: [0] });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 1,
       in1: 1,
       in2: 1,
@@ -84,13 +84,41 @@ it('should return 1 when all inputs are 0', () => {
   });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 0,
       in1: 0,
       in2: 0,
       in3: 0,
     }),
   ).toEqual({ out: [1] });
+});
+
+it("should return error when there's no 1 and there's one floating input", () => {
+  const model = new NorModel({
+    INPUT_PORTS_NUMBER: 2,
+    DATA_BITS: 1,
+  });
+
+  expect(
+    model.stepFloating({
+      in0: [0],
+      in1: ['x'],
+    }),
+  ).toEqual({ out: ['e'] });
+});
+
+it("should return error when there's no 1 and there's one error input", () => {
+  const model = new NorModel({
+    INPUT_PORTS_NUMBER: 2,
+    DATA_BITS: 1,
+  });
+
+  expect(
+    model.stepError({
+      in0: [0],
+      in1: ['e'],
+    }),
+  ).toEqual({ out: ['e'] });
 });
 
 it('should return bitwise NOR for multiple data bits', () => {
@@ -102,7 +130,7 @@ it('should return bitwise NOR for multiple data bits', () => {
   });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 0b0000_0000,
       in1: 0b0111_1000,
       in2: 0b0110_0110,

--- a/packages/@logossim/components/Nor/__tests__/NorModel.test.js
+++ b/packages/@logossim/components/Nor/__tests__/NorModel.test.js
@@ -2,141 +2,146 @@ import NorModel from '../NorModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const addInputSpy = jest.spyOn(NorModel.prototype, 'addInputPort');
-  addInputSpy.mockImplementation(addPort);
+describe('NorModel', () => {
+  it('should add ports on initialization', () => {
+    const addInputSpy = jest.spyOn(
+      NorModel.prototype,
+      'addInputPort',
+    );
+    addInputSpy.mockImplementation(addPort);
 
-  const addOutputSpy = jest.spyOn(
-    NorModel.prototype,
-    'addOutputPort',
-  );
-  addOutputSpy.mockImplementation(addPort);
+    const addOutputSpy = jest.spyOn(
+      NorModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  new NorModel({
-    INPUT_PORTS_NUMBER: 16,
-    DATA_BITS: 1,
-  });
+    new NorModel({
+      INPUT_PORTS_NUMBER: 16,
+      DATA_BITS: 1,
+    });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
-  [...Array(16).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
-      bits: 1,
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
+    [...Array(16).keys()].forEach(i => {
+      expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
+        bits: 1,
+      });
     });
   });
-});
 
-it("should return 0 when there's a 1 input", () => {
-  const model = new NorModel({
-    INPUT_PORTS_NUMBER: 4,
-    DATA_BITS: 1,
+  it("should return 0 when there's a 1 input", () => {
+    const model = new NorModel({
+      INPUT_PORTS_NUMBER: 4,
+      DATA_BITS: 1,
+    });
+
+    expect(
+      model.step({
+        in0: 1,
+        in1: 0,
+        in2: 0,
+        in3: 0,
+      }),
+    ).toEqual({ out: [0] });
+
+    expect(
+      model.step({
+        in0: 0,
+        in1: 1,
+        in2: 0,
+        in3: 0,
+      }),
+    ).toEqual({ out: [0] });
+
+    expect(
+      model.step({
+        in0: 0,
+        in1: 0,
+        in2: 1,
+        in3: 0,
+      }),
+    ).toEqual({ out: [0] });
+
+    expect(
+      model.step({
+        in0: 0,
+        in1: 0,
+        in2: 0,
+        in3: 1,
+      }),
+    ).toEqual({ out: [0] });
+
+    expect(
+      model.step({
+        in0: 1,
+        in1: 1,
+        in2: 1,
+        in3: 1,
+      }),
+    ).toEqual({ out: [0] });
   });
 
-  expect(
-    model.step({
-      in0: 1,
-      in1: 0,
-      in2: 0,
-      in3: 0,
-    }),
-  ).toEqual({ out: [0] });
+  it('should return 1 when all inputs are 0', () => {
+    const model = new NorModel({
+      INPUT_PORTS_NUMBER: 4,
+      DATA_BITS: 1,
+    });
 
-  expect(
-    model.step({
-      in0: 0,
-      in1: 1,
-      in2: 0,
-      in3: 0,
-    }),
-  ).toEqual({ out: [0] });
-
-  expect(
-    model.step({
-      in0: 0,
-      in1: 0,
-      in2: 1,
-      in3: 0,
-    }),
-  ).toEqual({ out: [0] });
-
-  expect(
-    model.step({
-      in0: 0,
-      in1: 0,
-      in2: 0,
-      in3: 1,
-    }),
-  ).toEqual({ out: [0] });
-
-  expect(
-    model.step({
-      in0: 1,
-      in1: 1,
-      in2: 1,
-      in3: 1,
-    }),
-  ).toEqual({ out: [0] });
-});
-
-it('should return 1 when all inputs are 0', () => {
-  const model = new NorModel({
-    INPUT_PORTS_NUMBER: 4,
-    DATA_BITS: 1,
+    expect(
+      model.step({
+        in0: 0,
+        in1: 0,
+        in2: 0,
+        in3: 0,
+      }),
+    ).toEqual({ out: [1] });
   });
 
-  expect(
-    model.step({
-      in0: 0,
-      in1: 0,
-      in2: 0,
-      in3: 0,
-    }),
-  ).toEqual({ out: [1] });
-});
+  it("should return error when there's no 1 and there's one floating input", () => {
+    const model = new NorModel({
+      INPUT_PORTS_NUMBER: 2,
+      DATA_BITS: 1,
+    });
 
-it("should return error when there's no 1 and there's one floating input", () => {
-  const model = new NorModel({
-    INPUT_PORTS_NUMBER: 2,
-    DATA_BITS: 1,
+    expect(
+      model.stepFloating({
+        in0: [0],
+        in1: ['x'],
+      }),
+    ).toEqual({ out: ['e'] });
   });
 
-  expect(
-    model.stepFloating({
-      in0: [0],
-      in1: ['x'],
-    }),
-  ).toEqual({ out: ['e'] });
-});
+  it("should return error when there's no 1 and there's one error input", () => {
+    const model = new NorModel({
+      INPUT_PORTS_NUMBER: 2,
+      DATA_BITS: 1,
+    });
 
-it("should return error when there's no 1 and there's one error input", () => {
-  const model = new NorModel({
-    INPUT_PORTS_NUMBER: 2,
-    DATA_BITS: 1,
+    expect(
+      model.stepError({
+        in0: [0],
+        in1: ['e'],
+      }),
+    ).toEqual({ out: ['e'] });
   });
 
-  expect(
-    model.stepError({
-      in0: [0],
-      in1: ['e'],
-    }),
-  ).toEqual({ out: ['e'] });
-});
+  it('should return bitwise NOR for multiple data bits', () => {
+    const DATA_BITS = 8;
 
-it('should return bitwise NOR for multiple data bits', () => {
-  const DATA_BITS = 8;
+    const model = new NorModel({
+      INPUT_PORTS_NUMBER: 5,
+      DATA_BITS,
+    });
 
-  const model = new NorModel({
-    INPUT_PORTS_NUMBER: 5,
-    DATA_BITS,
-  });
-
-  expect(
-    model.step({
-      in0: 0b0000_0000,
-      in1: 0b0111_1000,
-      in2: 0b0110_0110,
-      in3: 0b0101_0101,
-    }),
-  ).toEqual({
-    out: (0b1000_0000).asArray(DATA_BITS),
+    expect(
+      model.step({
+        in0: 0b0000_0000,
+        in1: 0b0111_1000,
+        in2: 0b0110_0110,
+        in3: 0b0101_0101,
+      }),
+    ).toEqual({
+      out: (0b1000_0000).asArray(DATA_BITS),
+    });
   });
 });

--- a/packages/@logossim/components/Nor/__tests__/NorWidget.test.jsx
+++ b/packages/@logossim/components/Nor/__tests__/NorWidget.test.jsx
@@ -1,20 +1,15 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import NorModel from '../NorModel';
 import NorWidget from '../NorWidget';
-
-const { engine } = global;
 
 it('should have 1 output port', () => {
   const model = new NorModel({
     DATA_BITS: 1,
   });
 
-  const { container } = render(
-    <NorWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<NorWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name=out]');
   expect(ports).toHaveLength(1);
@@ -26,9 +21,7 @@ it('should have the amount of input ports determined by configuration', () => {
     DATA_BITS: 1,
   });
 
-  const { container } = render(
-    <NorWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<NorWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name^=in]');
   expect(ports).toHaveLength(16);

--- a/packages/@logossim/components/Nor/__tests__/NorWidget.test.jsx
+++ b/packages/@logossim/components/Nor/__tests__/NorWidget.test.jsx
@@ -4,25 +4,27 @@ import { render } from '../../testUtils';
 import NorModel from '../NorModel';
 import NorWidget from '../NorWidget';
 
-it('should have 1 output port', () => {
-  const model = new NorModel({
-    DATA_BITS: 1,
+describe('NorWidget', () => {
+  it('should have 1 output port', () => {
+    const model = new NorModel({
+      DATA_BITS: 1,
+    });
+
+    const { container } = render(<NorWidget model={model} />);
+
+    const ports = container.querySelectorAll('[data-name=out]');
+    expect(ports).toHaveLength(1);
   });
 
-  const { container } = render(<NorWidget model={model} />);
+  it('should have the amount of input ports determined by configuration', () => {
+    const model = new NorModel({
+      INPUT_PORTS_NUMBER: 16,
+      DATA_BITS: 1,
+    });
 
-  const ports = container.querySelectorAll('[data-name=out]');
-  expect(ports).toHaveLength(1);
-});
+    const { container } = render(<NorWidget model={model} />);
 
-it('should have the amount of input ports determined by configuration', () => {
-  const model = new NorModel({
-    INPUT_PORTS_NUMBER: 16,
-    DATA_BITS: 1,
+    const ports = container.querySelectorAll('[data-name^=in]');
+    expect(ports).toHaveLength(16);
   });
-
-  const { container } = render(<NorWidget model={model} />);
-
-  const ports = container.querySelectorAll('[data-name^=in]');
-  expect(ports).toHaveLength(16);
 });

--- a/packages/@logossim/components/Not/NotModel.js
+++ b/packages/@logossim/components/Not/NotModel.js
@@ -2,15 +2,18 @@ import { BaseModel } from '@logossim/core';
 
 export default class NotModel extends BaseModel {
   initialize(configurations) {
-    const DATA_BITS = Number(configurations.DATA_BITS);
+    this.dataBits = Number(configurations.DATA_BITS);
 
-    this.addInputPort('in', { bits: DATA_BITS });
-    this.addOutputPort('out', { bits: DATA_BITS });
+    this.addInputPort('in', { bits: this.dataBits });
+    this.addOutputPort('out', { bits: this.dataBits });
   }
 
   step(input) {
     return {
-      out: ~input.in,
+      out: input.in.asArray(this.dataBits).map(bit => {
+        if (bit === 1) return 0;
+        return 1;
+      }),
     };
   }
 }

--- a/packages/@logossim/components/Not/NotModel.js
+++ b/packages/@logossim/components/Not/NotModel.js
@@ -4,8 +4,8 @@ export default class NotModel extends BaseModel {
   initialize(configurations) {
     const DATA_BITS = Number(configurations.DATA_BITS);
 
-    this.addInputPort('in', DATA_BITS);
-    this.addOutputPort('out', DATA_BITS);
+    this.addInputPort('in', { bits: DATA_BITS });
+    this.addOutputPort('out', { bits: DATA_BITS });
   }
 
   step(input) {

--- a/packages/@logossim/components/Not/NotWidget.jsx
+++ b/packages/@logossim/components/Not/NotWidget.jsx
@@ -59,18 +59,8 @@ const NotWidget = props => {
 
   return (
     <Wrapper selected={selected}>
-      <PositionedPort
-        name="in"
-        model={model}
-        port={model.getPort('in')}
-        engine={engine}
-      />
-      <PositionedPort
-        name="out"
-        model={model}
-        port={model.getPort('out')}
-        engine={engine}
-      />
+      <PositionedPort name="in" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} engine={engine} />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/Not/NotWidget.jsx
+++ b/packages/@logossim/components/Not/NotWidget.jsx
@@ -59,8 +59,8 @@ const NotWidget = props => {
 
   return (
     <Wrapper selected={selected}>
-      <PositionedPort name="in" model={model} />
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="in" />
+      <PositionedPort name="out" />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/Not/NotWidget.jsx
+++ b/packages/@logossim/components/Not/NotWidget.jsx
@@ -52,15 +52,15 @@ export const Shape = ({ size = 30 }) => (
 );
 
 const NotWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
   } = model;
 
   return (
     <Wrapper selected={selected}>
-      <PositionedPort name="in" model={model} engine={engine} />
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="in" model={model} />
+      <PositionedPort name="out" model={model} />
       <Shape />
     </Wrapper>
   );

--- a/packages/@logossim/components/Not/__tests__/NotModel.test.js
+++ b/packages/@logossim/components/Not/__tests__/NotModel.test.js
@@ -1,9 +1,3 @@
-/* eslint-disable no-new */
-import {
-  convertArrayValueToNumber,
-  convertNumberValueToArray,
-} from '@logossim/core/Simulation/utils';
-
 import NotModel from '../NotModel';
 
 const { addPort } = global;
@@ -56,6 +50,6 @@ it('should return the value negated for multiple bits', () => {
       in: 0b0101_1010,
     }),
   ).toEqual({
-    out: convertNumberValueToArray(0b1010_0101, DATA_BITS),
+    out: (0b1010_0101).asArray(DATA_BITS),
   });
 });

--- a/packages/@logossim/components/Not/__tests__/NotModel.test.js
+++ b/packages/@logossim/components/Not/__tests__/NotModel.test.js
@@ -22,8 +22,8 @@ it('should add ports on initialization', () => {
     DATA_BITS: 4,
   });
 
-  expect(addInputSpy).toHaveBeenCalledWith('in', 4);
-  expect(addOutputSpy).toHaveBeenCalledWith('out', 4);
+  expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 4 });
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
 });
 
 it('should return the value negated', () => {

--- a/packages/@logossim/components/Not/__tests__/NotModel.test.js
+++ b/packages/@logossim/components/Not/__tests__/NotModel.test.js
@@ -26,13 +26,13 @@ it('should return the value negated', () => {
   });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in: 0,
     }),
   ).toEqual({ out: [1] });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in: 1,
     }),
   ).toEqual({ out: [0] });
@@ -46,7 +46,7 @@ it('should return the value negated for multiple bits', () => {
   });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in: 0b0101_1010,
     }),
   ).toEqual({

--- a/packages/@logossim/components/Not/__tests__/NotModel.test.js
+++ b/packages/@logossim/components/Not/__tests__/NotModel.test.js
@@ -2,54 +2,59 @@ import NotModel from '../NotModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const addInputSpy = jest.spyOn(NotModel.prototype, 'addInputPort');
-  addInputSpy.mockImplementation(addPort);
+describe('NotModel', () => {
+  it('should add ports on initialization', () => {
+    const addInputSpy = jest.spyOn(
+      NotModel.prototype,
+      'addInputPort',
+    );
+    addInputSpy.mockImplementation(addPort);
 
-  const addOutputSpy = jest.spyOn(
-    NotModel.prototype,
-    'addOutputPort',
-  );
-  addOutputSpy.mockImplementation(addPort);
+    const addOutputSpy = jest.spyOn(
+      NotModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  new NotModel({
-    DATA_BITS: 4,
+    new NotModel({
+      DATA_BITS: 4,
+    });
+
+    expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 4 });
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
   });
 
-  expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 4 });
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 4 });
-});
+  it('should return the value negated', () => {
+    const model = new NotModel({
+      DATA_BITS: 1,
+    });
 
-it('should return the value negated', () => {
-  const model = new NotModel({
-    DATA_BITS: 1,
+    expect(
+      model.step({
+        in: 0,
+      }),
+    ).toEqual({ out: [1] });
+
+    expect(
+      model.step({
+        in: 1,
+      }),
+    ).toEqual({ out: [0] });
   });
 
-  expect(
-    model.step({
-      in: 0,
-    }),
-  ).toEqual({ out: [1] });
+  it('should return the value negated for multiple bits', () => {
+    const DATA_BITS = 8;
 
-  expect(
-    model.step({
-      in: 1,
-    }),
-  ).toEqual({ out: [0] });
-});
+    const model = new NotModel({
+      DATA_BITS,
+    });
 
-it('should return the value negated for multiple bits', () => {
-  const DATA_BITS = 8;
-
-  const model = new NotModel({
-    DATA_BITS,
-  });
-
-  expect(
-    model.step({
-      in: 0b0101_1010,
-    }),
-  ).toEqual({
-    out: (0b1010_0101).asArray(DATA_BITS),
+    expect(
+      model.step({
+        in: 0b0101_1010,
+      }),
+    ).toEqual({
+      out: (0b1010_0101).asArray(DATA_BITS),
+    });
   });
 });

--- a/packages/@logossim/components/Not/__tests__/NotWidget.test.jsx
+++ b/packages/@logossim/components/Not/__tests__/NotWidget.test.jsx
@@ -4,16 +4,18 @@ import { render } from '../../testUtils';
 import NotModel from '../NotModel';
 import NotWidget from '../NotWidget';
 
-it('should have 1 input and 1 output port', () => {
-  const model = new NotModel({
-    DATA_BITS: 1,
+describe('NotWidget', () => {
+  it('should have 1 input and 1 output port', () => {
+    const model = new NotModel({
+      DATA_BITS: 1,
+    });
+
+    const { container } = render(<NotWidget model={model} />);
+
+    const input = container.querySelector('[data-name=in]');
+    expect(input).toBeTruthy();
+
+    const output = container.querySelector('[data-name=out]');
+    expect(output).toBeTruthy();
   });
-
-  const { container } = render(<NotWidget model={model} />);
-
-  const input = container.querySelector('[data-name=in]');
-  expect(input).toBeTruthy();
-
-  const output = container.querySelector('[data-name=out]');
-  expect(output).toBeTruthy();
 });

--- a/packages/@logossim/components/Not/__tests__/NotWidget.test.jsx
+++ b/packages/@logossim/components/Not/__tests__/NotWidget.test.jsx
@@ -1,20 +1,15 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import NotModel from '../NotModel';
 import NotWidget from '../NotWidget';
-
-const { engine } = global;
 
 it('should have 1 input and 1 output port', () => {
   const model = new NotModel({
     DATA_BITS: 1,
   });
 
-  const { container } = render(
-    <NotWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<NotWidget model={model} />);
 
   const input = container.querySelector('[data-name=in]');
   expect(input).toBeTruthy();

--- a/packages/@logossim/components/Or/OrModel.js
+++ b/packages/@logossim/components/Or/OrModel.js
@@ -8,9 +8,9 @@ export default class OrModel extends BaseModel {
     const DATA_BITS = Number(configurations.DATA_BITS);
 
     for (let i = 0; i < INPUT_PORTS_NUMBER; i += 1) {
-      this.addInputPort(`in${i}`, DATA_BITS);
+      this.addInputPort(`in${i}`, { bits: DATA_BITS });
     }
-    this.addOutputPort('out', DATA_BITS);
+    this.addOutputPort('out', { bits: DATA_BITS });
   }
 
   step(input) {

--- a/packages/@logossim/components/Or/OrModel.js
+++ b/packages/@logossim/components/Or/OrModel.js
@@ -5,17 +5,34 @@ export default class OrModel extends BaseModel {
     const INPUT_PORTS_NUMBER = Number(
       configurations.INPUT_PORTS_NUMBER,
     );
-    const DATA_BITS = Number(configurations.DATA_BITS);
+    this.dataBits = Number(configurations.DATA_BITS);
 
     for (let i = 0; i < INPUT_PORTS_NUMBER; i += 1) {
-      this.addInputPort(`in${i}`, { bits: DATA_BITS });
+      this.addInputPort(`in${i}`, { bits: this.dataBits });
     }
-    this.addOutputPort('out', { bits: DATA_BITS });
+    this.addOutputPort('out', { bits: this.dataBits });
+  }
+
+  executeBit(bits) {
+    if (bits.every(bit => bit === 0)) return 0;
+    if (bits.some(bit => bit === 1)) return 1;
+    return 'e';
   }
 
   step(input) {
     return {
-      out: Object.values(input).reduce((acc, curr) => acc | curr),
+      out: Object.values(input)
+        .map(value => value.asArray(this.dataBits))
+        .transpose()
+        .map(this.executeBit),
     };
+  }
+
+  stepFloating(input) {
+    return this.step(input);
+  }
+
+  stepError(input) {
+    return this.step(input);
   }
 }

--- a/packages/@logossim/components/Or/OrWidget.jsx
+++ b/packages/@logossim/components/Or/OrWidget.jsx
@@ -94,7 +94,7 @@ export const Shape = ({ size = 90, portPositions = [] }) => (
 );
 
 const OrWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
 
   const inputPorts = Object.values(model.getInputPorts());
   const portPositions = distributePorts(inputPorts.length);
@@ -111,7 +111,6 @@ const OrWidget = props => {
           <PositionedPort
             name={port.getName()}
             model={model}
-            engine={engine}
             position={portPositions[i]}
           />
           {(portPositions[i] < 1 || portPositions[i] > 5) && (
@@ -122,7 +121,7 @@ const OrWidget = props => {
           )}
         </Fragment>
       ))}
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} />
       <Shape portPositions={portPositions} />
     </Wrapper>
   );

--- a/packages/@logossim/components/Or/OrWidget.jsx
+++ b/packages/@logossim/components/Or/OrWidget.jsx
@@ -110,7 +110,6 @@ const OrWidget = props => {
         <Fragment key={port.getName()}>
           <PositionedPort
             name={port.getName()}
-            model={model}
             position={portPositions[i]}
           />
           {(portPositions[i] < 1 || portPositions[i] > 5) && (
@@ -121,7 +120,7 @@ const OrWidget = props => {
           )}
         </Fragment>
       ))}
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="out" />
       <Shape portPositions={portPositions} />
     </Wrapper>
   );

--- a/packages/@logossim/components/Or/OrWidget.jsx
+++ b/packages/@logossim/components/Or/OrWidget.jsx
@@ -111,7 +111,6 @@ const OrWidget = props => {
           <PositionedPort
             name={port.getName()}
             model={model}
-            port={port}
             engine={engine}
             position={portPositions[i]}
           />
@@ -123,12 +122,7 @@ const OrWidget = props => {
           )}
         </Fragment>
       ))}
-      <PositionedPort
-        name="out"
-        model={model}
-        port={model.getPort('out')}
-        engine={engine}
-      />
+      <PositionedPort name="out" model={model} engine={engine} />
       <Shape portPositions={portPositions} />
     </Wrapper>
   );

--- a/packages/@logossim/components/Or/__tests__/OrModel.test.js
+++ b/packages/@logossim/components/Or/__tests__/OrModel.test.js
@@ -17,9 +17,11 @@ it('should add ports on initialization', () => {
     DATA_BITS: 1,
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', 1);
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
   [...Array(16).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, 1);
+    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
+      bits: 1,
+    });
   });
 });
 

--- a/packages/@logossim/components/Or/__tests__/OrModel.test.js
+++ b/packages/@logossim/components/Or/__tests__/OrModel.test.js
@@ -29,7 +29,7 @@ it("should return 1 when there's a 1 input", () => {
   });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 1,
       in1: 0,
       in2: 0,
@@ -38,7 +38,7 @@ it("should return 1 when there's a 1 input", () => {
   ).toEqual({ out: [1] });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 0,
       in1: 1,
       in2: 0,
@@ -47,7 +47,7 @@ it("should return 1 when there's a 1 input", () => {
   ).toEqual({ out: [1] });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 0,
       in1: 0,
       in2: 1,
@@ -56,7 +56,7 @@ it("should return 1 when there's a 1 input", () => {
   ).toEqual({ out: [1] });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 0,
       in1: 0,
       in2: 0,
@@ -65,7 +65,7 @@ it("should return 1 when there's a 1 input", () => {
   ).toEqual({ out: [1] });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 1,
       in1: 1,
       in2: 1,
@@ -81,13 +81,41 @@ it('should return 0 when all inputs are 0', () => {
   });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 0,
       in1: 0,
       in2: 0,
       in3: 0,
     }),
   ).toEqual({ out: [0] });
+});
+
+it("should return error when there's no 1 and there's one floating input", () => {
+  const model = new OrModel({
+    INPUT_PORTS_NUMBER: 2,
+    DATA_BITS: 1,
+  });
+
+  expect(
+    model.stepFloating({
+      in0: [0],
+      in1: ['x'],
+    }),
+  ).toEqual({ out: ['e'] });
+});
+
+it("should return error when there's no 1 and there's one error input", () => {
+  const model = new OrModel({
+    INPUT_PORTS_NUMBER: 2,
+    DATA_BITS: 1,
+  });
+
+  expect(
+    model.stepError({
+      in0: [0],
+      in1: ['e'],
+    }),
+  ).toEqual({ out: ['e'] });
 });
 
 it('should return bitwise OR for multiple data bits', () => {
@@ -99,7 +127,7 @@ it('should return bitwise OR for multiple data bits', () => {
   });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in0: 0b0000_0000,
       in1: 0b0111_1000,
       in2: 0b0110_0110,

--- a/packages/@logossim/components/Or/__tests__/OrModel.test.js
+++ b/packages/@logossim/components/Or/__tests__/OrModel.test.js
@@ -2,138 +2,143 @@ import OrModel from '../OrModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const addInputSpy = jest.spyOn(OrModel.prototype, 'addInputPort');
-  addInputSpy.mockImplementation(addPort);
+describe('OrModel', () => {
+  it('should add ports on initialization', () => {
+    const addInputSpy = jest.spyOn(OrModel.prototype, 'addInputPort');
+    addInputSpy.mockImplementation(addPort);
 
-  const addOutputSpy = jest.spyOn(OrModel.prototype, 'addOutputPort');
-  addOutputSpy.mockImplementation(addPort);
+    const addOutputSpy = jest.spyOn(
+      OrModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  new OrModel({
-    INPUT_PORTS_NUMBER: 16,
-    DATA_BITS: 1,
-  });
+    new OrModel({
+      INPUT_PORTS_NUMBER: 16,
+      DATA_BITS: 1,
+    });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
-  [...Array(16).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
-      bits: 1,
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
+    [...Array(16).keys()].forEach(i => {
+      expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
+        bits: 1,
+      });
     });
   });
-});
 
-it("should return 1 when there's a 1 input", () => {
-  const model = new OrModel({
-    INPUT_PORTS_NUMBER: 4,
-    DATA_BITS: 1,
+  it("should return 1 when there's a 1 input", () => {
+    const model = new OrModel({
+      INPUT_PORTS_NUMBER: 4,
+      DATA_BITS: 1,
+    });
+
+    expect(
+      model.step({
+        in0: 1,
+        in1: 0,
+        in2: 0,
+        in3: 0,
+      }),
+    ).toEqual({ out: [1] });
+
+    expect(
+      model.step({
+        in0: 0,
+        in1: 1,
+        in2: 0,
+        in3: 0,
+      }),
+    ).toEqual({ out: [1] });
+
+    expect(
+      model.step({
+        in0: 0,
+        in1: 0,
+        in2: 1,
+        in3: 0,
+      }),
+    ).toEqual({ out: [1] });
+
+    expect(
+      model.step({
+        in0: 0,
+        in1: 0,
+        in2: 0,
+        in3: 1,
+      }),
+    ).toEqual({ out: [1] });
+
+    expect(
+      model.step({
+        in0: 1,
+        in1: 1,
+        in2: 1,
+        in3: 1,
+      }),
+    ).toEqual({ out: [1] });
   });
 
-  expect(
-    model.step({
-      in0: 1,
-      in1: 0,
-      in2: 0,
-      in3: 0,
-    }),
-  ).toEqual({ out: [1] });
+  it('should return 0 when all inputs are 0', () => {
+    const model = new OrModel({
+      INPUT_PORTS_NUMBER: 4,
+      DATA_BITS: 1,
+    });
 
-  expect(
-    model.step({
-      in0: 0,
-      in1: 1,
-      in2: 0,
-      in3: 0,
-    }),
-  ).toEqual({ out: [1] });
-
-  expect(
-    model.step({
-      in0: 0,
-      in1: 0,
-      in2: 1,
-      in3: 0,
-    }),
-  ).toEqual({ out: [1] });
-
-  expect(
-    model.step({
-      in0: 0,
-      in1: 0,
-      in2: 0,
-      in3: 1,
-    }),
-  ).toEqual({ out: [1] });
-
-  expect(
-    model.step({
-      in0: 1,
-      in1: 1,
-      in2: 1,
-      in3: 1,
-    }),
-  ).toEqual({ out: [1] });
-});
-
-it('should return 0 when all inputs are 0', () => {
-  const model = new OrModel({
-    INPUT_PORTS_NUMBER: 4,
-    DATA_BITS: 1,
+    expect(
+      model.step({
+        in0: 0,
+        in1: 0,
+        in2: 0,
+        in3: 0,
+      }),
+    ).toEqual({ out: [0] });
   });
 
-  expect(
-    model.step({
-      in0: 0,
-      in1: 0,
-      in2: 0,
-      in3: 0,
-    }),
-  ).toEqual({ out: [0] });
-});
+  it("should return error when there's no 1 and there's one floating input", () => {
+    const model = new OrModel({
+      INPUT_PORTS_NUMBER: 2,
+      DATA_BITS: 1,
+    });
 
-it("should return error when there's no 1 and there's one floating input", () => {
-  const model = new OrModel({
-    INPUT_PORTS_NUMBER: 2,
-    DATA_BITS: 1,
+    expect(
+      model.stepFloating({
+        in0: [0],
+        in1: ['x'],
+      }),
+    ).toEqual({ out: ['e'] });
   });
 
-  expect(
-    model.stepFloating({
-      in0: [0],
-      in1: ['x'],
-    }),
-  ).toEqual({ out: ['e'] });
-});
+  it("should return error when there's no 1 and there's one error input", () => {
+    const model = new OrModel({
+      INPUT_PORTS_NUMBER: 2,
+      DATA_BITS: 1,
+    });
 
-it("should return error when there's no 1 and there's one error input", () => {
-  const model = new OrModel({
-    INPUT_PORTS_NUMBER: 2,
-    DATA_BITS: 1,
+    expect(
+      model.stepError({
+        in0: [0],
+        in1: ['e'],
+      }),
+    ).toEqual({ out: ['e'] });
   });
 
-  expect(
-    model.stepError({
-      in0: [0],
-      in1: ['e'],
-    }),
-  ).toEqual({ out: ['e'] });
-});
+  it('should return bitwise OR for multiple data bits', () => {
+    const DATA_BITS = 8;
 
-it('should return bitwise OR for multiple data bits', () => {
-  const DATA_BITS = 8;
+    const model = new OrModel({
+      INPUT_PORTS_NUMBER: 5,
+      DATA_BITS,
+    });
 
-  const model = new OrModel({
-    INPUT_PORTS_NUMBER: 5,
-    DATA_BITS,
-  });
-
-  expect(
-    model.step({
-      in0: 0b0000_0000,
-      in1: 0b0111_1000,
-      in2: 0b0110_0110,
-      in3: 0b0101_0101,
-    }),
-  ).toEqual({
-    out: (0b0111_1111).asArray(DATA_BITS),
+    expect(
+      model.step({
+        in0: 0b0000_0000,
+        in1: 0b0111_1000,
+        in2: 0b0110_0110,
+        in3: 0b0101_0101,
+      }),
+    ).toEqual({
+      out: (0b0111_1111).asArray(DATA_BITS),
+    });
   });
 });

--- a/packages/@logossim/components/Or/__tests__/OrModel.test.js
+++ b/packages/@logossim/components/Or/__tests__/OrModel.test.js
@@ -1,6 +1,3 @@
-/* eslint-disable no-new */
-import { convertNumberValueToArray } from '@logossim/core/Simulation/utils';
-
 import OrModel from '../OrModel';
 
 const { addPort } = global;
@@ -109,6 +106,6 @@ it('should return bitwise OR for multiple data bits', () => {
       in3: 0b0101_0101,
     }),
   ).toEqual({
-    out: convertNumberValueToArray(0b0111_1111, DATA_BITS),
+    out: (0b0111_1111).asArray(DATA_BITS),
   });
 });

--- a/packages/@logossim/components/Or/__tests__/OrWidget.test.jsx
+++ b/packages/@logossim/components/Or/__tests__/OrWidget.test.jsx
@@ -1,20 +1,15 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import OrModel from '../OrModel';
 import OrWidget from '../OrWidget';
-
-const { engine } = global;
 
 it('should have 1 output port', () => {
   const model = new OrModel({
     DATA_BITS: 1,
   });
 
-  const { container } = render(
-    <OrWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<OrWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name=out]');
   expect(ports).toHaveLength(1);
@@ -26,9 +21,7 @@ it('should have the amount of input ports determined by configuration', () => {
     DATA_BITS: 1,
   });
 
-  const { container } = render(
-    <OrWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<OrWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name^=in]');
   expect(ports).toHaveLength(16);

--- a/packages/@logossim/components/Or/__tests__/OrWidget.test.jsx
+++ b/packages/@logossim/components/Or/__tests__/OrWidget.test.jsx
@@ -4,25 +4,27 @@ import { render } from '../../testUtils';
 import OrModel from '../OrModel';
 import OrWidget from '../OrWidget';
 
-it('should have 1 output port', () => {
-  const model = new OrModel({
-    DATA_BITS: 1,
+describe('OrWidget', () => {
+  it('should have 1 output port', () => {
+    const model = new OrModel({
+      DATA_BITS: 1,
+    });
+
+    const { container } = render(<OrWidget model={model} />);
+
+    const ports = container.querySelectorAll('[data-name=out]');
+    expect(ports).toHaveLength(1);
   });
 
-  const { container } = render(<OrWidget model={model} />);
+  it('should have the amount of input ports determined by configuration', () => {
+    const model = new OrModel({
+      INPUT_PORTS_NUMBER: 16,
+      DATA_BITS: 1,
+    });
 
-  const ports = container.querySelectorAll('[data-name=out]');
-  expect(ports).toHaveLength(1);
-});
+    const { container } = render(<OrWidget model={model} />);
 
-it('should have the amount of input ports determined by configuration', () => {
-  const model = new OrModel({
-    INPUT_PORTS_NUMBER: 16,
-    DATA_BITS: 1,
+    const ports = container.querySelectorAll('[data-name^=in]');
+    expect(ports).toHaveLength(16);
   });
-
-  const { container } = render(<OrWidget model={model} />);
-
-  const ports = container.querySelectorAll('[data-name^=in]');
-  expect(ports).toHaveLength(16);
 });

--- a/packages/@logossim/components/Output/OutputModel.js
+++ b/packages/@logossim/components/Output/OutputModel.js
@@ -4,7 +4,7 @@ export default class OutputModel extends BaseModel {
   initialize(configurations) {
     this.dataBits = Number(configurations.DATA_BITS);
 
-    this.addInputPort('in', this.dataBits);
+    this.addInputPort('in', { bits: this.dataBits });
   }
 
   getInput() {

--- a/packages/@logossim/components/Output/OutputWidget.jsx
+++ b/packages/@logossim/components/Output/OutputWidget.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { Port } from '@logossim/core';
-import { convertArrayValueToNumber } from '@logossim/core/Simulation/utils';
 
 import styled from 'styled-components';
 
@@ -101,6 +100,12 @@ const ErrorMessage = styled.span`
   font-family: monospace;
 `;
 
+const FloatingMessage = styled.span`
+  color: var(--value-floating);
+  font-weight: bold;
+  font-family: monospace;
+`;
+
 const mapBits = model => {
   const {
     configurations: { DATA_BITS },
@@ -123,8 +128,10 @@ const mapBits = model => {
 };
 
 const showAsNumber = (input, format) => {
-  const number = convertArrayValueToNumber(input);
+  const number = input.asNumber();
   if (number === 'e') return <ErrorMessage>(error)</ErrorMessage>;
+  if (number === 'x')
+    return <FloatingMessage>(floating)</FloatingMessage>;
 
   if (format === 'DECIMAL') return number;
   if (format === 'HEXADECIMAL')

--- a/packages/@logossim/components/Output/OutputWidget.jsx
+++ b/packages/@logossim/components/Output/OutputWidget.jsx
@@ -152,12 +152,7 @@ const OutputWidget = props => {
           ? mapBits(model)
           : showAsNumber(model.getInput(), OUTPUT_FORMAT)}
       </PinContainer>
-      <PositionedPort
-        name="in"
-        model={model}
-        port={model.getPort('in')}
-        engine={engine}
-      />
+      <PositionedPort name="in" model={model} engine={engine} />
     </Shape>
   );
 };

--- a/packages/@logossim/components/Output/OutputWidget.jsx
+++ b/packages/@logossim/components/Output/OutputWidget.jsx
@@ -133,7 +133,7 @@ const showAsNumber = (input, format) => {
 };
 
 const OutputWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
     configurations: { OUTPUT_FORMAT, DATA_BITS },
@@ -152,7 +152,7 @@ const OutputWidget = props => {
           ? mapBits(model)
           : showAsNumber(model.getInput(), OUTPUT_FORMAT)}
       </PinContainer>
-      <PositionedPort name="in" model={model} engine={engine} />
+      <PositionedPort name="in" model={model} />
     </Shape>
   );
 };

--- a/packages/@logossim/components/Output/OutputWidget.jsx
+++ b/packages/@logossim/components/Output/OutputWidget.jsx
@@ -152,7 +152,7 @@ const OutputWidget = props => {
           ? mapBits(model)
           : showAsNumber(model.getInput(), OUTPUT_FORMAT)}
       </PinContainer>
-      <PositionedPort name="in" model={model} />
+      <PositionedPort name="in" />
     </Shape>
   );
 };

--- a/packages/@logossim/components/Output/OutputWidget.jsx
+++ b/packages/@logossim/components/Output/OutputWidget.jsx
@@ -68,7 +68,7 @@ export const Shape = styled.div`
 
 export const PinContainer = styled.span`
   display: flex;
-  flex-wrap: wrap-reverse;
+  flex-wrap: wrap;
   justify-content: space-evenly;
   align-items: center;
   font-family: monospace;

--- a/packages/@logossim/components/Output/__tests__/OutputModel.test.js
+++ b/packages/@logossim/components/Output/__tests__/OutputModel.test.js
@@ -2,11 +2,13 @@ import OutputModel from '../OutputModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const spy = jest.spyOn(OutputModel.prototype, 'addInputPort');
-  spy.mockImplementation(addPort);
+describe('OutputModel', () => {
+  it('should add ports on initialization', () => {
+    const spy = jest.spyOn(OutputModel.prototype, 'addInputPort');
+    spy.mockImplementation(addPort);
 
-  new OutputModel({ DATA_BITS: 1 });
+    new OutputModel({ DATA_BITS: 1 });
 
-  expect(spy).toHaveBeenCalledWith('in', { bits: 1 });
+    expect(spy).toHaveBeenCalledWith('in', { bits: 1 });
+  });
 });

--- a/packages/@logossim/components/Output/__tests__/OutputModel.test.js
+++ b/packages/@logossim/components/Output/__tests__/OutputModel.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import OutputModel from '../OutputModel';
 
 const { addPort } = global;

--- a/packages/@logossim/components/Output/__tests__/OutputModel.test.js
+++ b/packages/@logossim/components/Output/__tests__/OutputModel.test.js
@@ -9,5 +9,5 @@ it('should add ports on initialization', () => {
 
   new OutputModel({ DATA_BITS: 1 });
 
-  expect(spy).toHaveBeenCalledWith('in', 1);
+  expect(spy).toHaveBeenCalledWith('in', { bits: 1 });
 });

--- a/packages/@logossim/components/Output/__tests__/OutputWidget.test.jsx
+++ b/packages/@logossim/components/Output/__tests__/OutputWidget.test.jsx
@@ -1,18 +1,14 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render } from '../../testUtils';
 
 import OutputModel from '../OutputModel';
 import OutputWidget from '../OutputWidget';
 
-const { engine } = global;
-
 it('should have 1 input port', () => {
   const model = new OutputModel({ DATA_BITS: 1 });
 
-  const { container } = render(
-    <OutputWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<OutputWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name=in]');
   expect(ports).toHaveLength(1);
@@ -24,9 +20,7 @@ it('should have 1 pin when configured with 1-bit', () => {
     OUTPUT_FORMAT: 'BITS',
   });
 
-  const { getByTestId } = render(
-    <OutputWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<OutputWidget model={model} />);
 
   const pinContainer = getByTestId('pin-container');
   expect(pinContainer.children).toHaveLength(1);
@@ -38,9 +32,7 @@ it('should have 2 pins when configured with 2-bit', () => {
     OUTPUT_FORMAT: 'BITS',
   });
 
-  const { getByTestId } = render(
-    <OutputWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<OutputWidget model={model} />);
 
   const pinContainer = getByTestId('pin-container');
   expect(pinContainer.children).toHaveLength(2);
@@ -52,9 +44,7 @@ it('should have 4 pins when configured with 4-bit', () => {
     OUTPUT_FORMAT: 'BITS',
   });
 
-  const { getByTestId } = render(
-    <OutputWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<OutputWidget model={model} />);
 
   const pinContainer = getByTestId('pin-container');
   expect(pinContainer.children).toHaveLength(4);
@@ -66,9 +56,7 @@ it('should have 8 pins when configured with 8-bit', () => {
     OUTPUT_FORMAT: 'BITS',
   });
 
-  const { getByTestId } = render(
-    <OutputWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<OutputWidget model={model} />);
 
   const pinContainer = getByTestId('pin-container');
   expect(pinContainer.children).toHaveLength(8);
@@ -80,9 +68,7 @@ it('should have 16 pins when configured with 16-bit', () => {
     OUTPUT_FORMAT: 'BITS',
   });
 
-  const { getByTestId } = render(
-    <OutputWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<OutputWidget model={model} />);
 
   const pinContainer = getByTestId('pin-container');
   expect(pinContainer.children).toHaveLength(16);
@@ -113,9 +99,7 @@ it('should display pin values accordingly', () => {
     0,
   ]);
 
-  const { getByTestId } = render(
-    <OutputWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<OutputWidget model={model} />);
   const pinContainer = getByTestId('pin-container');
 
   Array.from(pinContainer.children).forEach((pin, i) => {
@@ -131,9 +115,7 @@ it('should display decimal values accordingly', () => {
   const spy = jest.spyOn(model, 'getInput');
   spy.mockImplementation(() => 0b1010_1010_1010_1010);
 
-  const { getByTestId } = render(
-    <OutputWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<OutputWidget model={model} />);
   const pinContainer = getByTestId('pin-container');
 
   expect(pinContainer).toContainHTML('43690');
@@ -147,9 +129,7 @@ it('should display hexadecimal values accordingly', () => {
   const spy = jest.spyOn(model, 'getInput');
   spy.mockImplementation(() => 0b1010_1010_1010_1010);
 
-  const { getByTestId } = render(
-    <OutputWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<OutputWidget model={model} />);
   const pinContainer = getByTestId('pin-container');
 
   expect(pinContainer).toContainHTML('0xaaaa');
@@ -163,9 +143,7 @@ it('should display errored values accordingly', () => {
   const spy = jest.spyOn(model, 'getInput');
   spy.mockImplementation(() => Array(16).fill('e'));
 
-  const { getByTestId } = render(
-    <OutputWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<OutputWidget model={model} />);
   const pinContainer = getByTestId('pin-container');
 
   expect(pinContainer).toContainHTML('(error)');

--- a/packages/@logossim/components/Output/__tests__/OutputWidget.test.jsx
+++ b/packages/@logossim/components/Output/__tests__/OutputWidget.test.jsx
@@ -1,150 +1,151 @@
 import React from 'react';
 
 import { render } from '../../testUtils';
-
 import OutputModel from '../OutputModel';
 import OutputWidget from '../OutputWidget';
 
-it('should have 1 input port', () => {
-  const model = new OutputModel({ DATA_BITS: 1 });
+describe('OutputWidget', () => {
+  it('should have 1 input port', () => {
+    const model = new OutputModel({ DATA_BITS: 1 });
 
-  const { container } = render(<OutputWidget model={model} />);
+    const { container } = render(<OutputWidget model={model} />);
 
-  const ports = container.querySelectorAll('[data-name=in]');
-  expect(ports).toHaveLength(1);
-});
-
-it('should have 1 pin when configured with 1-bit', () => {
-  const model = new OutputModel({
-    DATA_BITS: 1,
-    OUTPUT_FORMAT: 'BITS',
+    const ports = container.querySelectorAll('[data-name=in]');
+    expect(ports).toHaveLength(1);
   });
 
-  const { getByTestId } = render(<OutputWidget model={model} />);
+  it('should have 1 pin when configured with 1-bit', () => {
+    const model = new OutputModel({
+      DATA_BITS: 1,
+      OUTPUT_FORMAT: 'BITS',
+    });
 
-  const pinContainer = getByTestId('pin-container');
-  expect(pinContainer.children).toHaveLength(1);
-});
+    const { getByTestId } = render(<OutputWidget model={model} />);
 
-it('should have 2 pins when configured with 2-bit', () => {
-  const model = new OutputModel({
-    DATA_BITS: 2,
-    OUTPUT_FORMAT: 'BITS',
+    const pinContainer = getByTestId('pin-container');
+    expect(pinContainer.children).toHaveLength(1);
   });
 
-  const { getByTestId } = render(<OutputWidget model={model} />);
+  it('should have 2 pins when configured with 2-bit', () => {
+    const model = new OutputModel({
+      DATA_BITS: 2,
+      OUTPUT_FORMAT: 'BITS',
+    });
 
-  const pinContainer = getByTestId('pin-container');
-  expect(pinContainer.children).toHaveLength(2);
-});
+    const { getByTestId } = render(<OutputWidget model={model} />);
 
-it('should have 4 pins when configured with 4-bit', () => {
-  const model = new OutputModel({
-    DATA_BITS: 4,
-    OUTPUT_FORMAT: 'BITS',
+    const pinContainer = getByTestId('pin-container');
+    expect(pinContainer.children).toHaveLength(2);
   });
 
-  const { getByTestId } = render(<OutputWidget model={model} />);
+  it('should have 4 pins when configured with 4-bit', () => {
+    const model = new OutputModel({
+      DATA_BITS: 4,
+      OUTPUT_FORMAT: 'BITS',
+    });
 
-  const pinContainer = getByTestId('pin-container');
-  expect(pinContainer.children).toHaveLength(4);
-});
+    const { getByTestId } = render(<OutputWidget model={model} />);
 
-it('should have 8 pins when configured with 8-bit', () => {
-  const model = new OutputModel({
-    DATA_BITS: 8,
-    OUTPUT_FORMAT: 'BITS',
+    const pinContainer = getByTestId('pin-container');
+    expect(pinContainer.children).toHaveLength(4);
   });
 
-  const { getByTestId } = render(<OutputWidget model={model} />);
+  it('should have 8 pins when configured with 8-bit', () => {
+    const model = new OutputModel({
+      DATA_BITS: 8,
+      OUTPUT_FORMAT: 'BITS',
+    });
 
-  const pinContainer = getByTestId('pin-container');
-  expect(pinContainer.children).toHaveLength(8);
-});
+    const { getByTestId } = render(<OutputWidget model={model} />);
 
-it('should have 16 pins when configured with 16-bit', () => {
-  const model = new OutputModel({
-    DATA_BITS: 16,
-    OUTPUT_FORMAT: 'BITS',
+    const pinContainer = getByTestId('pin-container');
+    expect(pinContainer.children).toHaveLength(8);
   });
 
-  const { getByTestId } = render(<OutputWidget model={model} />);
+  it('should have 16 pins when configured with 16-bit', () => {
+    const model = new OutputModel({
+      DATA_BITS: 16,
+      OUTPUT_FORMAT: 'BITS',
+    });
 
-  const pinContainer = getByTestId('pin-container');
-  expect(pinContainer.children).toHaveLength(16);
-});
+    const { getByTestId } = render(<OutputWidget model={model} />);
 
-it('should display pin values accordingly', () => {
-  const model = new OutputModel({
-    DATA_BITS: 16,
-    OUTPUT_FORMAT: 'BITS',
+    const pinContainer = getByTestId('pin-container');
+    expect(pinContainer.children).toHaveLength(16);
   });
-  const spy = jest.spyOn(model, 'getInput');
-  spy.mockImplementation(() => [
-    1,
-    0,
-    1,
-    0,
-    1,
-    0,
-    1,
-    0,
-    1,
-    0,
-    1,
-    0,
-    1,
-    0,
-    1,
-    0,
-  ]);
 
-  const { getByTestId } = render(<OutputWidget model={model} />);
-  const pinContainer = getByTestId('pin-container');
+  it('should display pin values accordingly', () => {
+    const model = new OutputModel({
+      DATA_BITS: 16,
+      OUTPUT_FORMAT: 'BITS',
+    });
+    const spy = jest.spyOn(model, 'getInput');
+    spy.mockImplementation(() => [
+      1,
+      0,
+      1,
+      0,
+      1,
+      0,
+      1,
+      0,
+      1,
+      0,
+      1,
+      0,
+      1,
+      0,
+      1,
+      0,
+    ]);
 
-  Array.from(pinContainer.children).forEach((pin, i) => {
-    expect(pin).toContainHTML(i % 2 ? '0' : '1');
+    const { getByTestId } = render(<OutputWidget model={model} />);
+    const pinContainer = getByTestId('pin-container');
+
+    Array.from(pinContainer.children).forEach((pin, i) => {
+      expect(pin).toContainHTML(i % 2 ? '0' : '1');
+    });
   });
-});
 
-it('should display decimal values accordingly', () => {
-  const model = new OutputModel({
-    DATA_BITS: 16,
-    OUTPUT_FORMAT: 'DECIMAL',
+  it('should display decimal values accordingly', () => {
+    const model = new OutputModel({
+      DATA_BITS: 16,
+      OUTPUT_FORMAT: 'DECIMAL',
+    });
+    const spy = jest.spyOn(model, 'getInput');
+    spy.mockImplementation(() => 0b1010_1010_1010_1010);
+
+    const { getByTestId } = render(<OutputWidget model={model} />);
+    const pinContainer = getByTestId('pin-container');
+
+    expect(pinContainer).toContainHTML('43690');
   });
-  const spy = jest.spyOn(model, 'getInput');
-  spy.mockImplementation(() => 0b1010_1010_1010_1010);
 
-  const { getByTestId } = render(<OutputWidget model={model} />);
-  const pinContainer = getByTestId('pin-container');
+  it('should display hexadecimal values accordingly', () => {
+    const model = new OutputModel({
+      DATA_BITS: 16,
+      OUTPUT_FORMAT: 'HEXADECIMAL',
+    });
+    const spy = jest.spyOn(model, 'getInput');
+    spy.mockImplementation(() => 0b1010_1010_1010_1010);
 
-  expect(pinContainer).toContainHTML('43690');
-});
+    const { getByTestId } = render(<OutputWidget model={model} />);
+    const pinContainer = getByTestId('pin-container');
 
-it('should display hexadecimal values accordingly', () => {
-  const model = new OutputModel({
-    DATA_BITS: 16,
-    OUTPUT_FORMAT: 'HEXADECIMAL',
+    expect(pinContainer).toContainHTML('0xaaaa');
   });
-  const spy = jest.spyOn(model, 'getInput');
-  spy.mockImplementation(() => 0b1010_1010_1010_1010);
 
-  const { getByTestId } = render(<OutputWidget model={model} />);
-  const pinContainer = getByTestId('pin-container');
+  it('should display errored values accordingly', () => {
+    const model = new OutputModel({
+      DATA_BITS: 16,
+      OUTPUT_FORMAT: 'DECIMAL',
+    });
+    const spy = jest.spyOn(model, 'getInput');
+    spy.mockImplementation(() => Array(16).fill('e'));
 
-  expect(pinContainer).toContainHTML('0xaaaa');
-});
+    const { getByTestId } = render(<OutputWidget model={model} />);
+    const pinContainer = getByTestId('pin-container');
 
-it('should display errored values accordingly', () => {
-  const model = new OutputModel({
-    DATA_BITS: 16,
-    OUTPUT_FORMAT: 'DECIMAL',
+    expect(pinContainer).toContainHTML('(error)');
   });
-  const spy = jest.spyOn(model, 'getInput');
-  spy.mockImplementation(() => Array(16).fill('e'));
-
-  const { getByTestId } = render(<OutputWidget model={model} />);
-  const pinContainer = getByTestId('pin-container');
-
-  expect(pinContainer).toContainHTML('(error)');
 });

--- a/packages/@logossim/components/Power/PowerModel.js
+++ b/packages/@logossim/components/Power/PowerModel.js
@@ -4,7 +4,7 @@ export default class PowerModel extends BaseModel {
   initialize(configurations) {
     this.dataBits = Number(configurations.DATA_BITS);
 
-    this.addOutputPort('out', this.dataBits);
+    this.addOutputPort('out', { bits: this.dataBits });
   }
 
   onSimulationStart() {

--- a/packages/@logossim/components/Power/PowerWidget.jsx
+++ b/packages/@logossim/components/Power/PowerWidget.jsx
@@ -57,12 +57,7 @@ const PowerWidget = props => {
   return (
     <Wrapper>
       <Shape selected={selected} dataBits={model.dataBits} />
-      <PositionedPort
-        name="out"
-        model={model}
-        port={model.getPort('out')}
-        engine={engine}
-      />
+      <PositionedPort name="out" model={model} engine={engine} />
     </Wrapper>
   );
 };

--- a/packages/@logossim/components/Power/PowerWidget.jsx
+++ b/packages/@logossim/components/Power/PowerWidget.jsx
@@ -57,7 +57,7 @@ const PowerWidget = props => {
   return (
     <Wrapper>
       <Shape selected={selected} dataBits={model.dataBits} />
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="out" />
     </Wrapper>
   );
 };

--- a/packages/@logossim/components/Power/PowerWidget.jsx
+++ b/packages/@logossim/components/Power/PowerWidget.jsx
@@ -49,7 +49,7 @@ export const Shape = ({ selected, dataBits = 1 }) => {
 };
 
 const PowerWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
   } = model;
@@ -57,7 +57,7 @@ const PowerWidget = props => {
   return (
     <Wrapper>
       <Shape selected={selected} dataBits={model.dataBits} />
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} />
     </Wrapper>
   );
 };

--- a/packages/@logossim/components/Power/__tests__/PowerModel.test.js
+++ b/packages/@logossim/components/Power/__tests__/PowerModel.test.js
@@ -2,27 +2,29 @@ import PowerModel from '../PowerModel';
 
 const { addPort } = global;
 
-it('should add output port on initialization', () => {
-  const addOutputSpy = jest.spyOn(
-    PowerModel.prototype,
-    'addOutputPort',
-  );
-  addOutputSpy.mockImplementation(addPort);
+describe('PowerModel', () => {
+  it('should add output port on initialization', () => {
+    const addOutputSpy = jest.spyOn(
+      PowerModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  new PowerModel({
-    DATA_BITS: 16,
+    new PowerModel({
+      DATA_BITS: 16,
+    });
+
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 16 });
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 16 });
-});
+  it('should always return high values', () => {
+    const model = new PowerModel({
+      DATA_BITS: 16,
+    });
+    const spy = jest.spyOn(model, 'emit');
 
-it('should always return high values', () => {
-  const model = new PowerModel({
-    DATA_BITS: 16,
+    model.onSimulationStart();
+
+    expect(spy).toHaveBeenCalledWith({ out: 0b1111_1111_1111_1111 });
   });
-  const spy = jest.spyOn(model, 'emit');
-
-  model.onSimulationStart();
-
-  expect(spy).toHaveBeenCalledWith({ out: 0b1111_1111_1111_1111 });
 });

--- a/packages/@logossim/components/Power/__tests__/PowerModel.test.js
+++ b/packages/@logossim/components/Power/__tests__/PowerModel.test.js
@@ -14,7 +14,7 @@ it('should add output port on initialization', () => {
     DATA_BITS: 16,
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', 16);
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 16 });
 });
 
 it('should always return high values', () => {

--- a/packages/@logossim/components/Power/__tests__/PowerModel.test.js
+++ b/packages/@logossim/components/Power/__tests__/PowerModel.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import PowerModel from '../PowerModel';
 
 const { addPort } = global;

--- a/packages/@logossim/components/Power/__tests__/PowerWidget.test.jsx
+++ b/packages/@logossim/components/Power/__tests__/PowerWidget.test.jsx
@@ -4,13 +4,15 @@ import { render } from '../../testUtils';
 import PowerModel from '../PowerModel';
 import PowerWidget from '../PowerWidget';
 
-it('should have 1 output port', () => {
-  const model = new PowerModel({
-    DATA_BITS: 1,
+describe('PowerWidget', () => {
+  it('should have 1 output port', () => {
+    const model = new PowerModel({
+      DATA_BITS: 1,
+    });
+
+    const { container } = render(<PowerWidget model={model} />);
+
+    const port = container.querySelector('[data-name=out]');
+    expect(port).toBeTruthy();
   });
-
-  const { container } = render(<PowerWidget model={model} />);
-
-  const port = container.querySelector('[data-name=out]');
-  expect(port).toBeTruthy();
 });

--- a/packages/@logossim/components/Power/__tests__/PowerWidget.test.jsx
+++ b/packages/@logossim/components/Power/__tests__/PowerWidget.test.jsx
@@ -1,20 +1,15 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import PowerModel from '../PowerModel';
 import PowerWidget from '../PowerWidget';
-
-const { engine } = global;
 
 it('should have 1 output port', () => {
   const model = new PowerModel({
     DATA_BITS: 1,
   });
 
-  const { container } = render(
-    <PowerWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<PowerWidget model={model} />);
 
   const port = container.querySelector('[data-name=out]');
   expect(port).toBeTruthy();

--- a/packages/@logossim/components/Ram/RamIcon.jsx
+++ b/packages/@logossim/components/Ram/RamIcon.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+const Icon = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 30px;
+  height: 30px;
+  font-size: 10px;
+
+  background: var(--body-unselected);
+  border: 1px solid var(--border-unselected);
+`;
+
+const RamIcon = () => <Icon>RAM</Icon>;
+
+export default RamIcon;

--- a/packages/@logossim/components/Ram/RamModel.js
+++ b/packages/@logossim/components/Ram/RamModel.js
@@ -1,0 +1,57 @@
+import { BaseModel } from '@logossim/core';
+
+export default class RamModel extends BaseModel {
+  initialize(configurations) {
+    this.dataWidth = Number(configurations.DATA_WIDTH);
+    this.addressWidth = Number(configurations.ADDRESS_WIDTH);
+    this.memory = (configurations.CONTENT || '').parseBinary(
+      this.dataWidth,
+      2 ** this.addressWidth,
+    );
+
+    this.addInputPort('clock', { floating: 0 });
+    this.addInputPort('load', { floating: 1 });
+    this.addInputPort('address', {
+      bits: this.addressWidth,
+      floating: 0,
+    });
+    this.addInputPort('clear', { floating: 0 });
+    this.addInputPort('select', { floating: 1 });
+    this.addOutputPort('data', { bits: this.dataWidth });
+  }
+
+  clearMemory() {
+    this.memory = Array(2 ** this.addressWidth).fill(0);
+  }
+
+  getMemory() {
+    return this.memory;
+  }
+
+  getAddress() {
+    if (!this.select) return 0;
+    return (this.currentAddress || 0).asNumber();
+  }
+
+  step(input, meta) {
+    this.currentAddress = input.address;
+    this.select = input.select;
+
+    if (input.clear) this.clearMemory();
+    if (!input.select) return { data: 'x' };
+
+    if (!input.load) {
+      if (meta.clock.risingEdge && !input.clear) {
+        this.memory[input.address] = this.getPort('data')
+          .getWireValue()
+          .asNumber();
+      }
+
+      return { data: 'x' };
+    }
+
+    return {
+      data: this.memory[input.address],
+    };
+  }
+}

--- a/packages/@logossim/components/Ram/RamRegister.js
+++ b/packages/@logossim/components/Ram/RamRegister.js
@@ -1,0 +1,74 @@
+import { Component } from '@logossim/core';
+
+import icon from './RamIcon';
+import model from './RamModel';
+import widget from './RamWidget';
+
+export default new Component({
+  type: 'Ram',
+  name: 'RAM',
+  description: 'Random access memory',
+  group: 'Memory',
+  configurations: [
+    {
+      name: 'DATA_WIDTH',
+      type: 'select',
+      default: '1',
+      label: 'Data width',
+      options: [
+        {
+          label: '1 bit',
+          value: '1',
+        },
+        {
+          label: '2 bits',
+          value: '2',
+        },
+        {
+          label: '4 bits',
+          value: '4',
+        },
+        {
+          label: '8 bits',
+          value: '8',
+        },
+        {
+          label: '16 bits',
+          value: '16',
+        },
+      ],
+    },
+    {
+      name: 'ADDRESS_WIDTH',
+      type: 'select',
+      default: '1',
+      label: 'Address width',
+      options: [
+        {
+          label: '1 bit',
+          value: '1',
+        },
+        {
+          label: '2 bits',
+          value: '2',
+        },
+        {
+          label: '4 bits',
+          value: '4',
+        },
+        {
+          label: '8 bits',
+          value: '8',
+        },
+      ],
+    },
+    {
+      name: 'CONTENT',
+      type: 'binary',
+      label: 'Initial content',
+    },
+  ],
+  model,
+  widget,
+  icon,
+});

--- a/packages/@logossim/components/Ram/RamWidget.jsx
+++ b/packages/@logossim/components/Ram/RamWidget.jsx
@@ -1,0 +1,148 @@
+import React from 'react';
+
+import { Port } from '@logossim/core';
+
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  position: relative;
+
+  width: 180px;
+  height: 150px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background: ${props =>
+    props.selected
+      ? 'var(--body-selected)'
+      : 'var(--body-unselected)'};
+  border: 1px solid
+    ${props =>
+      props.selected
+        ? 'var(--border-selected)'
+        : 'var(--border-unselected)'};
+
+  transition: 100ms linear;
+`;
+
+const Memory = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  overflow: hidden;
+  background: white;
+  border: 2px solid #c9c9c9;
+
+  width: 80%;
+  height: 112px;
+  font-size: 10px;
+`;
+
+const Cell = styled.div`
+  display: flex;
+  border-bottom: 1px solid #c9c9c9;
+  padding: 0 4px;
+`;
+
+const ActiveAddress = styled.div`
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 4px 0 4px 8px;
+  border-color: ${({ isSelected }) =>
+    `transparent transparent transparent ${
+      isSelected ? '#f44336' : 'transparent'
+    }`};
+  margin: auto 4px auto -4px;
+`;
+
+const AddressValueContainer = styled.div`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Address = styled.span`
+  margin-right: 4px;
+  padding: 1px 4px;
+  height: fit-content;
+
+  font-family: monospace;
+  font-size: 8px;
+  color: white;
+
+  background: #2642a0;
+  border-radius: 2px;
+`;
+
+const Value = styled.span`
+  padding: 4px;
+`;
+
+const PositionedPort = styled(Port)`
+  position: absolute;
+
+  ${props => {
+    if (props.name === 'clock') return 'bottom: -5px';
+    if (props.name === 'load')
+      return 'bottom: -5px; right: calc(50% - 20px)';
+    if (props.name === 'clear')
+      return 'bottom: -5px; right: calc(50% - 35px)';
+    if (props.name === 'select')
+      return 'bottom: -5px; right: calc(50% - 50px)';
+    if (props.name === 'address') return 'left: -5px';
+    if (props.name === 'data') return 'right: -5px';
+    return '';
+  }}
+`;
+
+const getMemoryDisplayRange = (memory, address) => {
+  if (address <= 1) return [0, 5];
+  if (address >= memory.length - 2)
+    return [memory.length - 5, memory.length];
+  return [address - 2, address + 3];
+};
+
+const RamWidget = props => {
+  const { model } = props;
+  const memory = model.getMemory();
+  const selectedAddress = model.getAddress();
+  const range = getMemoryDisplayRange(memory, selectedAddress);
+
+  return (
+    <Wrapper selected={model.isSelected()}>
+      <PositionedPort name="clock" />
+      <PositionedPort name="load" />
+      <PositionedPort name="address" />
+      <PositionedPort name="data" />
+      <PositionedPort name="clear" />
+      <PositionedPort name="select" />
+
+      <Memory>
+        {memory.slice(...range).map((value, index) => {
+          const address = index + range[0];
+          const formattedAddress = `0x${address
+            .toString(16)
+            .padStart(2, '0')}`;
+
+          return (
+            <Cell key={formattedAddress}>
+              <ActiveAddress
+                isSelected={address === selectedAddress}
+              />
+              <AddressValueContainer>
+                <Address>{formattedAddress}</Address>
+                <Value isSelected>{value}</Value>
+              </AddressValueContainer>
+            </Cell>
+          );
+        })}
+      </Memory>
+    </Wrapper>
+  );
+};
+
+export default RamWidget;

--- a/packages/@logossim/components/Ram/__tests__/RamModel.test.js
+++ b/packages/@logossim/components/Ram/__tests__/RamModel.test.js
@@ -2,218 +2,229 @@ import RamModel from '../RamModel';
 
 const { addPort } = global;
 
-beforeEach(() => {
-  const getPortSpy = jest.spyOn(RamModel.prototype, 'getPort');
-  getPortSpy.mockImplementation(() => ({
-    getWireValue: () => ({ asNumber: () => 5 }),
-  }));
-});
-
-it('should add ports on initialization', () => {
-  const addInputSpy = jest.spyOn(RamModel.prototype, 'addInputPort');
-  addInputSpy.mockImplementation(addPort);
-
-  const addOutputSpy = jest.spyOn(
-    RamModel.prototype,
-    'addOutputPort',
-  );
-  addOutputSpy.mockImplementation(addPort);
-
-  new RamModel({
-    DATA_WIDTH: 2,
-    ADDRESS_WIDTH: 4,
+describe('RamModel', () => {
+  beforeEach(() => {
+    const getPortSpy = jest.spyOn(RamModel.prototype, 'getPort');
+    getPortSpy.mockImplementation(() => ({
+      getWireValue: () => ({ asNumber: () => 5 }),
+    }));
   });
 
-  expect(addInputSpy).toHaveBeenCalledWith('clock', { floating: 0 });
-  expect(addInputSpy).toHaveBeenCalledWith('load', { floating: 1 });
-  expect(addInputSpy).toHaveBeenCalledWith('address', {
-    bits: 4,
-    floating: 0,
-  });
-  expect(addInputSpy).toHaveBeenCalledWith('clear', { floating: 0 });
-  expect(addInputSpy).toHaveBeenCalledWith('select', { floating: 1 });
-  expect(addOutputSpy).toHaveBeenCalledWith('data', { bits: 2 });
-});
+  it('should add ports on initialization', () => {
+    const addInputSpy = jest.spyOn(
+      RamModel.prototype,
+      'addInputPort',
+    );
+    addInputSpy.mockImplementation(addPort);
 
-it('should be correctly initialized', () => {
-  const model = new RamModel({
-    DATA_WIDTH: 1,
-    ADDRESS_WIDTH: 8,
-  });
-  const memory = model.getMemory();
+    const addOutputSpy = jest.spyOn(
+      RamModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  expect(memory).toHaveLength(256);
-  memory.forEach(value => expect(value).toEqual(0));
-});
+    new RamModel({
+      DATA_WIDTH: 2,
+      ADDRESS_WIDTH: 4,
+    });
 
-it('should be correcly initialized with content defined in configuration', () => {
-  const model = new RamModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
-    CONTENT: '0001 0010 0100 1000',
-  });
-  const memory = model.getMemory();
-
-  expect(memory[0]).toEqual(1);
-  expect(memory[1]).toEqual(2);
-  expect(memory[2]).toEqual(4);
-  expect(memory[3]).toEqual(8);
-  expect(memory).toHaveLength(16);
-});
-
-it('should asynchronously output value of given address to the data port', () => {
-  const model = new RamModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
-    CONTENT: '0001 0010 0100 1000',
+    expect(addInputSpy).toHaveBeenCalledWith('clock', {
+      floating: 0,
+    });
+    expect(addInputSpy).toHaveBeenCalledWith('load', { floating: 1 });
+    expect(addInputSpy).toHaveBeenCalledWith('address', {
+      bits: 4,
+      floating: 0,
+    });
+    expect(addInputSpy).toHaveBeenCalledWith('clear', {
+      floating: 0,
+    });
+    expect(addInputSpy).toHaveBeenCalledWith('select', {
+      floating: 1,
+    });
+    expect(addOutputSpy).toHaveBeenCalledWith('data', { bits: 2 });
   });
 
-  [0, 1, 2, 3].forEach(address =>
-    expect(
-      model.step(
-        {
-          address,
-          select: 1,
-          load: 1,
-        },
-        { clock: { risingEdge: false } },
-      ),
-    ).toEqual({ data: 2 ** address }),
-  );
-});
+  it('should be correctly initialized', () => {
+    const model = new RamModel({
+      DATA_WIDTH: 1,
+      ADDRESS_WIDTH: 8,
+    });
+    const memory = model.getMemory();
 
-it('should not output to data port if select is not set', () => {
-  const model = new RamModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
-    CONTENT: '0001 0010 0100 1000',
+    expect(memory).toHaveLength(256);
+    memory.forEach(value => expect(value).toEqual(0));
   });
 
-  [0, 1, 2, 3].forEach(address =>
-    expect(
-      model.step(
-        {
-          address,
-          select: 0,
-          load: 1,
-        },
-        { clock: { risingEdge: false } },
-      ),
-    ).toEqual({ data: 'x' }),
-  );
-});
+  it('should be correcly initialized with content defined in configuration', () => {
+    const model = new RamModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+      CONTENT: '0001 0010 0100 1000',
+    });
+    const memory = model.getMemory();
 
-it('should asynchronously clear the memory when the clear port is set', () => {
-  const model = new RamModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
-    CONTENT: '0001 0010 0100 1000',
+    expect(memory[0]).toEqual(1);
+    expect(memory[1]).toEqual(2);
+    expect(memory[2]).toEqual(4);
+    expect(memory[3]).toEqual(8);
+    expect(memory).toHaveLength(16);
   });
 
-  model.step({
-    clear: 1,
-    select: 0,
+  it('should asynchronously output value of given address to the data port', () => {
+    const model = new RamModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+      CONTENT: '0001 0010 0100 1000',
+    });
+
+    [0, 1, 2, 3].forEach(address =>
+      expect(
+        model.step(
+          {
+            address,
+            select: 1,
+            load: 1,
+          },
+          { clock: { risingEdge: false } },
+        ),
+      ).toEqual({ data: 2 ** address }),
+    );
   });
 
-  model.getMemory().forEach(value => expect(value).toEqual(0));
-});
+  it('should not output to data port if select is not set', () => {
+    const model = new RamModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+      CONTENT: '0001 0010 0100 1000',
+    });
 
-it('should synchronously store data', () => {
-  const model = new RamModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
+    [0, 1, 2, 3].forEach(address =>
+      expect(
+        model.step(
+          {
+            address,
+            select: 0,
+            load: 1,
+          },
+          { clock: { risingEdge: false } },
+        ),
+      ).toEqual({ data: 'x' }),
+    );
   });
 
-  const { data } = model.step(
-    {
-      address: 12,
-      load: 0,
-      clear: 0,
-      select: 1,
-    },
-    { clock: { risingEdge: true } },
-  );
+  it('should asynchronously clear the memory when the clear port is set', () => {
+    const model = new RamModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+      CONTENT: '0001 0010 0100 1000',
+    });
 
-  expect(model.getMemory()[12]).toEqual(5);
-  expect(data).toEqual('x');
-});
-
-it('should not asynchronously store data', () => {
-  const model = new RamModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
-  });
-
-  const { data } = model.step(
-    {
-      address: 12,
-      load: 0,
-      clear: 0,
-      select: 1,
-    },
-    { clock: { risingEdge: false } },
-  );
-
-  expect(model.getMemory()[12]).toEqual(0);
-  expect(data).toEqual('x');
-});
-
-it('should not store data if clear is set', () => {
-  const model = new RamModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
-  });
-
-  const { data } = model.step(
-    {
-      address: 12,
-      load: 0,
+    model.step({
       clear: 1,
-      select: 1,
-    },
-    { clock: { risingEdge: true } },
-  );
-
-  expect(model.getMemory()[12]).toEqual(0);
-  expect(data).toEqual('x');
-});
-
-it('should not store data if not selected', () => {
-  const model = new RamModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
-  });
-
-  const { data } = model.step(
-    {
-      address: 12,
-      load: 0,
-      clear: 0,
       select: 0,
-    },
-    { clock: { risingEdge: true } },
-  );
+    });
 
-  expect(model.getMemory()[12]).toEqual(0);
-  expect(data).toEqual('x');
-});
-
-it('should not store data if load is set', () => {
-  const model = new RamModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
+    model.getMemory().forEach(value => expect(value).toEqual(0));
   });
 
-  const { data } = model.step(
-    {
-      address: 12,
-      load: 1,
-      clear: 0,
-      select: 1,
-    },
-    { clock: { risingEdge: true } },
-  );
+  it('should synchronously store data', () => {
+    const model = new RamModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+    });
 
-  expect(model.getMemory()[12]).toEqual(0);
-  expect(data).toEqual(0);
+    const { data } = model.step(
+      {
+        address: 12,
+        load: 0,
+        clear: 0,
+        select: 1,
+      },
+      { clock: { risingEdge: true } },
+    );
+
+    expect(model.getMemory()[12]).toEqual(5);
+    expect(data).toEqual('x');
+  });
+
+  it('should not asynchronously store data', () => {
+    const model = new RamModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+    });
+
+    const { data } = model.step(
+      {
+        address: 12,
+        load: 0,
+        clear: 0,
+        select: 1,
+      },
+      { clock: { risingEdge: false } },
+    );
+
+    expect(model.getMemory()[12]).toEqual(0);
+    expect(data).toEqual('x');
+  });
+
+  it('should not store data if clear is set', () => {
+    const model = new RamModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+    });
+
+    const { data } = model.step(
+      {
+        address: 12,
+        load: 0,
+        clear: 1,
+        select: 1,
+      },
+      { clock: { risingEdge: true } },
+    );
+
+    expect(model.getMemory()[12]).toEqual(0);
+    expect(data).toEqual('x');
+  });
+
+  it('should not store data if not selected', () => {
+    const model = new RamModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+    });
+
+    const { data } = model.step(
+      {
+        address: 12,
+        load: 0,
+        clear: 0,
+        select: 0,
+      },
+      { clock: { risingEdge: true } },
+    );
+
+    expect(model.getMemory()[12]).toEqual(0);
+    expect(data).toEqual('x');
+  });
+
+  it('should not store data if load is set', () => {
+    const model = new RamModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+    });
+
+    const { data } = model.step(
+      {
+        address: 12,
+        load: 1,
+        clear: 0,
+        select: 1,
+      },
+      { clock: { risingEdge: true } },
+    );
+
+    expect(model.getMemory()[12]).toEqual(0);
+    expect(data).toEqual(0);
+  });
 });

--- a/packages/@logossim/components/Ram/__tests__/RamModel.test.js
+++ b/packages/@logossim/components/Ram/__tests__/RamModel.test.js
@@ -1,0 +1,219 @@
+import RamModel from '../RamModel';
+
+const { addPort } = global;
+
+beforeEach(() => {
+  const getPortSpy = jest.spyOn(RamModel.prototype, 'getPort');
+  getPortSpy.mockImplementation(() => ({
+    getWireValue: () => ({ asNumber: () => 5 }),
+  }));
+});
+
+it('should add ports on initialization', () => {
+  const addInputSpy = jest.spyOn(RamModel.prototype, 'addInputPort');
+  addInputSpy.mockImplementation(addPort);
+
+  const addOutputSpy = jest.spyOn(
+    RamModel.prototype,
+    'addOutputPort',
+  );
+  addOutputSpy.mockImplementation(addPort);
+
+  new RamModel({
+    DATA_WIDTH: 2,
+    ADDRESS_WIDTH: 4,
+  });
+
+  expect(addInputSpy).toHaveBeenCalledWith('clock', { floating: 0 });
+  expect(addInputSpy).toHaveBeenCalledWith('load', { floating: 1 });
+  expect(addInputSpy).toHaveBeenCalledWith('address', {
+    bits: 4,
+    floating: 0,
+  });
+  expect(addInputSpy).toHaveBeenCalledWith('clear', { floating: 0 });
+  expect(addInputSpy).toHaveBeenCalledWith('select', { floating: 1 });
+  expect(addOutputSpy).toHaveBeenCalledWith('data', { bits: 2 });
+});
+
+it('should be correctly initialized', () => {
+  const model = new RamModel({
+    DATA_WIDTH: 1,
+    ADDRESS_WIDTH: 8,
+  });
+  const memory = model.getMemory();
+
+  expect(memory).toHaveLength(256);
+  memory.forEach(value => expect(value).toEqual(0));
+});
+
+it('should be correcly initialized with content defined in configuration', () => {
+  const model = new RamModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+    CONTENT: '0001 0010 0100 1000',
+  });
+  const memory = model.getMemory();
+
+  expect(memory[0]).toEqual(1);
+  expect(memory[1]).toEqual(2);
+  expect(memory[2]).toEqual(4);
+  expect(memory[3]).toEqual(8);
+  expect(memory).toHaveLength(16);
+});
+
+it('should asynchronously output value of given address to the data port', () => {
+  const model = new RamModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+    CONTENT: '0001 0010 0100 1000',
+  });
+
+  [0, 1, 2, 3].forEach(address =>
+    expect(
+      model.step(
+        {
+          address,
+          select: 1,
+          load: 1,
+        },
+        { clock: { risingEdge: false } },
+      ),
+    ).toEqual({ data: 2 ** address }),
+  );
+});
+
+it('should not output to data port if select is not set', () => {
+  const model = new RamModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+    CONTENT: '0001 0010 0100 1000',
+  });
+
+  [0, 1, 2, 3].forEach(address =>
+    expect(
+      model.step(
+        {
+          address,
+          select: 0,
+          load: 1,
+        },
+        { clock: { risingEdge: false } },
+      ),
+    ).toEqual({ data: 'x' }),
+  );
+});
+
+it('should asynchronously clear the memory when the clear port is set', () => {
+  const model = new RamModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+    CONTENT: '0001 0010 0100 1000',
+  });
+
+  model.step({
+    clear: 1,
+    select: 0,
+  });
+
+  model.getMemory().forEach(value => expect(value).toEqual(0));
+});
+
+it('should synchronously store data', () => {
+  const model = new RamModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+  });
+
+  const { data } = model.step(
+    {
+      address: 12,
+      load: 0,
+      clear: 0,
+      select: 1,
+    },
+    { clock: { risingEdge: true } },
+  );
+
+  expect(model.getMemory()[12]).toEqual(5);
+  expect(data).toEqual('x');
+});
+
+it('should not asynchronously store data', () => {
+  const model = new RamModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+  });
+
+  const { data } = model.step(
+    {
+      address: 12,
+      load: 0,
+      clear: 0,
+      select: 1,
+    },
+    { clock: { risingEdge: false } },
+  );
+
+  expect(model.getMemory()[12]).toEqual(0);
+  expect(data).toEqual('x');
+});
+
+it('should not store data if clear is set', () => {
+  const model = new RamModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+  });
+
+  const { data } = model.step(
+    {
+      address: 12,
+      load: 0,
+      clear: 1,
+      select: 1,
+    },
+    { clock: { risingEdge: true } },
+  );
+
+  expect(model.getMemory()[12]).toEqual(0);
+  expect(data).toEqual('x');
+});
+
+it('should not store data if not selected', () => {
+  const model = new RamModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+  });
+
+  const { data } = model.step(
+    {
+      address: 12,
+      load: 0,
+      clear: 0,
+      select: 0,
+    },
+    { clock: { risingEdge: true } },
+  );
+
+  expect(model.getMemory()[12]).toEqual(0);
+  expect(data).toEqual('x');
+});
+
+it('should not store data if load is set', () => {
+  const model = new RamModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+  });
+
+  const { data } = model.step(
+    {
+      address: 12,
+      load: 1,
+      clear: 0,
+      select: 1,
+    },
+    { clock: { risingEdge: true } },
+  );
+
+  expect(model.getMemory()[12]).toEqual(0);
+  expect(data).toEqual(0);
+});

--- a/packages/@logossim/components/Ram/__tests__/RamWidget.test.jsx
+++ b/packages/@logossim/components/Ram/__tests__/RamWidget.test.jsx
@@ -38,27 +38,6 @@ it('should have the correct input ports', () => {
   expect(select).toBeTruthy();
 });
 
-it('should have the correct input ports', () => {
-  const model = new RamModel({
-    DATA_WIDTH: 1,
-    ADDRESS_WIDTH: 8,
-  });
-
-  const { container } = render(<RamWidget model={model} />);
-
-  const address = container.querySelector('[data-name=address]');
-  const clock = container.querySelector('[data-name=clock]');
-  const load = container.querySelector('[data-name=load]');
-  const clear = container.querySelector('[data-name=clear]');
-  const select = container.querySelector('[data-name=select]');
-
-  expect(address).toBeTruthy();
-  expect(clock).toBeTruthy();
-  expect(load).toBeTruthy();
-  expect(clear).toBeTruthy();
-  expect(select).toBeTruthy();
-});
-
 it('should display the first 5 values for the first 3 addresses', () => {
   const model = new RamModel({
     DATA_WIDTH: 4,

--- a/packages/@logossim/components/Ram/__tests__/RamWidget.test.jsx
+++ b/packages/@logossim/components/Ram/__tests__/RamWidget.test.jsx
@@ -1,0 +1,246 @@
+import React from 'react';
+
+import { render } from '../../testUtils';
+import RamModel from '../RamModel';
+import RamWidget from '../RamWidget';
+
+it('should have 1 output port', () => {
+  const model = new RamModel({
+    DATA_WIDTH: 1,
+    ADDRESS_WIDTH: 8,
+  });
+
+  const { container } = render(<RamWidget model={model} />);
+
+  const data = container.querySelector('[data-name=data]');
+
+  expect(data).toBeTruthy();
+});
+
+it('should have the correct input ports', () => {
+  const model = new RamModel({
+    DATA_WIDTH: 1,
+    ADDRESS_WIDTH: 8,
+  });
+
+  const { container } = render(<RamWidget model={model} />);
+
+  const address = container.querySelector('[data-name=address]');
+  const clock = container.querySelector('[data-name=clock]');
+  const load = container.querySelector('[data-name=load]');
+  const clear = container.querySelector('[data-name=clear]');
+  const select = container.querySelector('[data-name=select]');
+
+  expect(address).toBeTruthy();
+  expect(clock).toBeTruthy();
+  expect(load).toBeTruthy();
+  expect(clear).toBeTruthy();
+  expect(select).toBeTruthy();
+});
+
+it('should have the correct input ports', () => {
+  const model = new RamModel({
+    DATA_WIDTH: 1,
+    ADDRESS_WIDTH: 8,
+  });
+
+  const { container } = render(<RamWidget model={model} />);
+
+  const address = container.querySelector('[data-name=address]');
+  const clock = container.querySelector('[data-name=clock]');
+  const load = container.querySelector('[data-name=load]');
+  const clear = container.querySelector('[data-name=clear]');
+  const select = container.querySelector('[data-name=select]');
+
+  expect(address).toBeTruthy();
+  expect(clock).toBeTruthy();
+  expect(load).toBeTruthy();
+  expect(clear).toBeTruthy();
+  expect(select).toBeTruthy();
+});
+
+it('should display the first 5 values for the first 3 addresses', () => {
+  const model = new RamModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+    CONTENT: '0001 0010 0100 1000 1111',
+  });
+  model.getAddress = () => 0;
+
+  const { getByText, rerender } = render(<RamWidget model={model} />);
+
+  expect(getByText('0x00')).toBeTruthy();
+  expect(getByText('0x00').nextSibling).toHaveTextContent(1);
+
+  expect(getByText('0x01')).toBeTruthy();
+  expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+
+  expect(getByText('0x02')).toBeTruthy();
+  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+
+  expect(getByText('0x03')).toBeTruthy();
+  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+  expect(getByText('0x04')).toBeTruthy();
+  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+
+  model.getAddress = () => 1;
+  rerender(<RamWidget model={model} />);
+
+  expect(getByText('0x00')).toBeTruthy();
+  expect(getByText('0x00').nextSibling).toHaveTextContent(1);
+
+  expect(getByText('0x01')).toBeTruthy();
+  expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+
+  expect(getByText('0x02')).toBeTruthy();
+  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+
+  expect(getByText('0x03')).toBeTruthy();
+  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+  expect(getByText('0x04')).toBeTruthy();
+  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+
+  model.getAddress = () => 2;
+  rerender(<RamWidget model={model} />);
+
+  expect(getByText('0x00')).toBeTruthy();
+  expect(getByText('0x00').nextSibling).toHaveTextContent(1);
+
+  expect(getByText('0x01')).toBeTruthy();
+  expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+
+  expect(getByText('0x02')).toBeTruthy();
+  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+
+  expect(getByText('0x03')).toBeTruthy();
+  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+  expect(getByText('0x04')).toBeTruthy();
+  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+});
+
+it('should display the adjacent values for addresses in the middle', () => {
+  const model = new RamModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+    CONTENT: '0001 0010 0100 1000 1111',
+  });
+  model.getAddress = () => 3;
+
+  const { getByText, rerender } = render(<RamWidget model={model} />);
+
+  expect(getByText('0x01')).toBeTruthy();
+  expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+
+  expect(getByText('0x02')).toBeTruthy();
+  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+
+  expect(getByText('0x03')).toBeTruthy();
+  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+  expect(getByText('0x04')).toBeTruthy();
+  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+
+  expect(getByText('0x05')).toBeTruthy();
+  expect(getByText('0x05').nextSibling).toHaveTextContent(0);
+
+  model.getAddress = () => 4;
+  rerender(<RamWidget model={model} />);
+
+  expect(getByText('0x02')).toBeTruthy();
+  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+
+  expect(getByText('0x03')).toBeTruthy();
+  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+  expect(getByText('0x04')).toBeTruthy();
+  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+
+  expect(getByText('0x05')).toBeTruthy();
+  expect(getByText('0x05').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x06')).toBeTruthy();
+  expect(getByText('0x06').nextSibling).toHaveTextContent(0);
+
+  model.getAddress = () => 5;
+  rerender(<RamWidget model={model} />);
+
+  expect(getByText('0x03')).toBeTruthy();
+  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+  expect(getByText('0x04')).toBeTruthy();
+  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+
+  expect(getByText('0x05')).toBeTruthy();
+  expect(getByText('0x05').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x06')).toBeTruthy();
+  expect(getByText('0x06').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x07')).toBeTruthy();
+  expect(getByText('0x07').nextSibling).toHaveTextContent(0);
+});
+
+it('should display the last 5 values for the last 3 addresses', () => {
+  const model = new RamModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+    CONTENT: '0001 0010 0100 1000 1111',
+  });
+  model.getAddress = () => 13;
+
+  const { getByText, rerender } = render(<RamWidget model={model} />);
+
+  expect(getByText('0x0b')).toBeTruthy();
+  expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0c')).toBeTruthy();
+  expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0d')).toBeTruthy();
+  expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0e')).toBeTruthy();
+  expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0f')).toBeTruthy();
+  expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
+
+  model.getAddress = () => 14;
+  rerender(<RamWidget model={model} />);
+
+  expect(getByText('0x0b')).toBeTruthy();
+  expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0c')).toBeTruthy();
+  expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0d')).toBeTruthy();
+  expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0e')).toBeTruthy();
+  expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0f')).toBeTruthy();
+  expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
+
+  model.getAddress = () => 15;
+  rerender(<RamWidget model={model} />);
+
+  expect(getByText('0x0b')).toBeTruthy();
+  expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0c')).toBeTruthy();
+  expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0d')).toBeTruthy();
+  expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0e')).toBeTruthy();
+  expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0f')).toBeTruthy();
+  expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
+});

--- a/packages/@logossim/components/Ram/__tests__/RamWidget.test.jsx
+++ b/packages/@logossim/components/Ram/__tests__/RamWidget.test.jsx
@@ -4,222 +4,230 @@ import { render } from '../../testUtils';
 import RamModel from '../RamModel';
 import RamWidget from '../RamWidget';
 
-it('should have 1 output port', () => {
-  const model = new RamModel({
-    DATA_WIDTH: 1,
-    ADDRESS_WIDTH: 8,
+describe('RamWidget', () => {
+  it('should have 1 output port', () => {
+    const model = new RamModel({
+      DATA_WIDTH: 1,
+      ADDRESS_WIDTH: 8,
+    });
+
+    const { container } = render(<RamWidget model={model} />);
+
+    const data = container.querySelector('[data-name=data]');
+
+    expect(data).toBeTruthy();
   });
 
-  const { container } = render(<RamWidget model={model} />);
+  it('should have the correct input ports', () => {
+    const model = new RamModel({
+      DATA_WIDTH: 1,
+      ADDRESS_WIDTH: 8,
+    });
 
-  const data = container.querySelector('[data-name=data]');
+    const { container } = render(<RamWidget model={model} />);
 
-  expect(data).toBeTruthy();
-});
+    const address = container.querySelector('[data-name=address]');
+    const clock = container.querySelector('[data-name=clock]');
+    const load = container.querySelector('[data-name=load]');
+    const clear = container.querySelector('[data-name=clear]');
+    const select = container.querySelector('[data-name=select]');
 
-it('should have the correct input ports', () => {
-  const model = new RamModel({
-    DATA_WIDTH: 1,
-    ADDRESS_WIDTH: 8,
+    expect(address).toBeTruthy();
+    expect(clock).toBeTruthy();
+    expect(load).toBeTruthy();
+    expect(clear).toBeTruthy();
+    expect(select).toBeTruthy();
   });
 
-  const { container } = render(<RamWidget model={model} />);
+  it('should display the first 5 values for the first 3 addresses', () => {
+    const model = new RamModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+      CONTENT: '0001 0010 0100 1000 1111',
+    });
+    model.getAddress = () => 0;
 
-  const address = container.querySelector('[data-name=address]');
-  const clock = container.querySelector('[data-name=clock]');
-  const load = container.querySelector('[data-name=load]');
-  const clear = container.querySelector('[data-name=clear]');
-  const select = container.querySelector('[data-name=select]');
+    const { getByText, rerender } = render(
+      <RamWidget model={model} />,
+    );
 
-  expect(address).toBeTruthy();
-  expect(clock).toBeTruthy();
-  expect(load).toBeTruthy();
-  expect(clear).toBeTruthy();
-  expect(select).toBeTruthy();
-});
+    expect(getByText('0x00')).toBeTruthy();
+    expect(getByText('0x00').nextSibling).toHaveTextContent(1);
 
-it('should display the first 5 values for the first 3 addresses', () => {
-  const model = new RamModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
-    CONTENT: '0001 0010 0100 1000 1111',
+    expect(getByText('0x01')).toBeTruthy();
+    expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+
+    expect(getByText('0x02')).toBeTruthy();
+    expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+
+    expect(getByText('0x03')).toBeTruthy();
+    expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+    expect(getByText('0x04')).toBeTruthy();
+    expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+
+    model.getAddress = () => 1;
+    rerender(<RamWidget model={model} />);
+
+    expect(getByText('0x00')).toBeTruthy();
+    expect(getByText('0x00').nextSibling).toHaveTextContent(1);
+
+    expect(getByText('0x01')).toBeTruthy();
+    expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+
+    expect(getByText('0x02')).toBeTruthy();
+    expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+
+    expect(getByText('0x03')).toBeTruthy();
+    expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+    expect(getByText('0x04')).toBeTruthy();
+    expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+
+    model.getAddress = () => 2;
+    rerender(<RamWidget model={model} />);
+
+    expect(getByText('0x00')).toBeTruthy();
+    expect(getByText('0x00').nextSibling).toHaveTextContent(1);
+
+    expect(getByText('0x01')).toBeTruthy();
+    expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+
+    expect(getByText('0x02')).toBeTruthy();
+    expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+
+    expect(getByText('0x03')).toBeTruthy();
+    expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+    expect(getByText('0x04')).toBeTruthy();
+    expect(getByText('0x04').nextSibling).toHaveTextContent(15);
   });
-  model.getAddress = () => 0;
 
-  const { getByText, rerender } = render(<RamWidget model={model} />);
+  it('should display the adjacent values for addresses in the middle', () => {
+    const model = new RamModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+      CONTENT: '0001 0010 0100 1000 1111',
+    });
+    model.getAddress = () => 3;
 
-  expect(getByText('0x00')).toBeTruthy();
-  expect(getByText('0x00').nextSibling).toHaveTextContent(1);
+    const { getByText, rerender } = render(
+      <RamWidget model={model} />,
+    );
 
-  expect(getByText('0x01')).toBeTruthy();
-  expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+    expect(getByText('0x01')).toBeTruthy();
+    expect(getByText('0x01').nextSibling).toHaveTextContent(2);
 
-  expect(getByText('0x02')).toBeTruthy();
-  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+    expect(getByText('0x02')).toBeTruthy();
+    expect(getByText('0x02').nextSibling).toHaveTextContent(4);
 
-  expect(getByText('0x03')).toBeTruthy();
-  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+    expect(getByText('0x03')).toBeTruthy();
+    expect(getByText('0x03').nextSibling).toHaveTextContent(8);
 
-  expect(getByText('0x04')).toBeTruthy();
-  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+    expect(getByText('0x04')).toBeTruthy();
+    expect(getByText('0x04').nextSibling).toHaveTextContent(15);
 
-  model.getAddress = () => 1;
-  rerender(<RamWidget model={model} />);
+    expect(getByText('0x05')).toBeTruthy();
+    expect(getByText('0x05').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x00')).toBeTruthy();
-  expect(getByText('0x00').nextSibling).toHaveTextContent(1);
+    model.getAddress = () => 4;
+    rerender(<RamWidget model={model} />);
 
-  expect(getByText('0x01')).toBeTruthy();
-  expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+    expect(getByText('0x02')).toBeTruthy();
+    expect(getByText('0x02').nextSibling).toHaveTextContent(4);
 
-  expect(getByText('0x02')).toBeTruthy();
-  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+    expect(getByText('0x03')).toBeTruthy();
+    expect(getByText('0x03').nextSibling).toHaveTextContent(8);
 
-  expect(getByText('0x03')).toBeTruthy();
-  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+    expect(getByText('0x04')).toBeTruthy();
+    expect(getByText('0x04').nextSibling).toHaveTextContent(15);
 
-  expect(getByText('0x04')).toBeTruthy();
-  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+    expect(getByText('0x05')).toBeTruthy();
+    expect(getByText('0x05').nextSibling).toHaveTextContent(0);
 
-  model.getAddress = () => 2;
-  rerender(<RamWidget model={model} />);
+    expect(getByText('0x06')).toBeTruthy();
+    expect(getByText('0x06').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x00')).toBeTruthy();
-  expect(getByText('0x00').nextSibling).toHaveTextContent(1);
+    model.getAddress = () => 5;
+    rerender(<RamWidget model={model} />);
 
-  expect(getByText('0x01')).toBeTruthy();
-  expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+    expect(getByText('0x03')).toBeTruthy();
+    expect(getByText('0x03').nextSibling).toHaveTextContent(8);
 
-  expect(getByText('0x02')).toBeTruthy();
-  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+    expect(getByText('0x04')).toBeTruthy();
+    expect(getByText('0x04').nextSibling).toHaveTextContent(15);
 
-  expect(getByText('0x03')).toBeTruthy();
-  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+    expect(getByText('0x05')).toBeTruthy();
+    expect(getByText('0x05').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x04')).toBeTruthy();
-  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
-});
+    expect(getByText('0x06')).toBeTruthy();
+    expect(getByText('0x06').nextSibling).toHaveTextContent(0);
 
-it('should display the adjacent values for addresses in the middle', () => {
-  const model = new RamModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
-    CONTENT: '0001 0010 0100 1000 1111',
+    expect(getByText('0x07')).toBeTruthy();
+    expect(getByText('0x07').nextSibling).toHaveTextContent(0);
   });
-  model.getAddress = () => 3;
 
-  const { getByText, rerender } = render(<RamWidget model={model} />);
+  it('should display the last 5 values for the last 3 addresses', () => {
+    const model = new RamModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+      CONTENT: '0001 0010 0100 1000 1111',
+    });
+    model.getAddress = () => 13;
 
-  expect(getByText('0x01')).toBeTruthy();
-  expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+    const { getByText, rerender } = render(
+      <RamWidget model={model} />,
+    );
 
-  expect(getByText('0x02')).toBeTruthy();
-  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+    expect(getByText('0x0b')).toBeTruthy();
+    expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x03')).toBeTruthy();
-  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+    expect(getByText('0x0c')).toBeTruthy();
+    expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x04')).toBeTruthy();
-  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+    expect(getByText('0x0d')).toBeTruthy();
+    expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x05')).toBeTruthy();
-  expect(getByText('0x05').nextSibling).toHaveTextContent(0);
+    expect(getByText('0x0e')).toBeTruthy();
+    expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
 
-  model.getAddress = () => 4;
-  rerender(<RamWidget model={model} />);
+    expect(getByText('0x0f')).toBeTruthy();
+    expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x02')).toBeTruthy();
-  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+    model.getAddress = () => 14;
+    rerender(<RamWidget model={model} />);
 
-  expect(getByText('0x03')).toBeTruthy();
-  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+    expect(getByText('0x0b')).toBeTruthy();
+    expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x04')).toBeTruthy();
-  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+    expect(getByText('0x0c')).toBeTruthy();
+    expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x05')).toBeTruthy();
-  expect(getByText('0x05').nextSibling).toHaveTextContent(0);
+    expect(getByText('0x0d')).toBeTruthy();
+    expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x06')).toBeTruthy();
-  expect(getByText('0x06').nextSibling).toHaveTextContent(0);
+    expect(getByText('0x0e')).toBeTruthy();
+    expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
 
-  model.getAddress = () => 5;
-  rerender(<RamWidget model={model} />);
+    expect(getByText('0x0f')).toBeTruthy();
+    expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x03')).toBeTruthy();
-  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+    model.getAddress = () => 15;
+    rerender(<RamWidget model={model} />);
 
-  expect(getByText('0x04')).toBeTruthy();
-  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+    expect(getByText('0x0b')).toBeTruthy();
+    expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x05')).toBeTruthy();
-  expect(getByText('0x05').nextSibling).toHaveTextContent(0);
+    expect(getByText('0x0c')).toBeTruthy();
+    expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x06')).toBeTruthy();
-  expect(getByText('0x06').nextSibling).toHaveTextContent(0);
+    expect(getByText('0x0d')).toBeTruthy();
+    expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x07')).toBeTruthy();
-  expect(getByText('0x07').nextSibling).toHaveTextContent(0);
-});
+    expect(getByText('0x0e')).toBeTruthy();
+    expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
 
-it('should display the last 5 values for the last 3 addresses', () => {
-  const model = new RamModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
-    CONTENT: '0001 0010 0100 1000 1111',
+    expect(getByText('0x0f')).toBeTruthy();
+    expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
   });
-  model.getAddress = () => 13;
-
-  const { getByText, rerender } = render(<RamWidget model={model} />);
-
-  expect(getByText('0x0b')).toBeTruthy();
-  expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0c')).toBeTruthy();
-  expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0d')).toBeTruthy();
-  expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0e')).toBeTruthy();
-  expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0f')).toBeTruthy();
-  expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
-
-  model.getAddress = () => 14;
-  rerender(<RamWidget model={model} />);
-
-  expect(getByText('0x0b')).toBeTruthy();
-  expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0c')).toBeTruthy();
-  expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0d')).toBeTruthy();
-  expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0e')).toBeTruthy();
-  expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0f')).toBeTruthy();
-  expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
-
-  model.getAddress = () => 15;
-  rerender(<RamWidget model={model} />);
-
-  expect(getByText('0x0b')).toBeTruthy();
-  expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0c')).toBeTruthy();
-  expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0d')).toBeTruthy();
-  expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0e')).toBeTruthy();
-  expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0f')).toBeTruthy();
-  expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
 });

--- a/packages/@logossim/components/Rom/RomIcon.jsx
+++ b/packages/@logossim/components/Rom/RomIcon.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+const Icon = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 30px;
+  height: 30px;
+  font-size: 10px;
+
+  background: var(--body-unselected);
+  border: 1px solid var(--border-unselected);
+`;
+
+const RomIcon = () => <Icon>ROM</Icon>;
+
+export default RomIcon;

--- a/packages/@logossim/components/Rom/RomModel.js
+++ b/packages/@logossim/components/Rom/RomModel.js
@@ -1,0 +1,39 @@
+import { BaseModel } from '@logossim/core';
+
+export default class RomModel extends BaseModel {
+  initialize(configurations) {
+    this.dataWidth = Number(configurations.DATA_WIDTH);
+    this.addressWidth = Number(configurations.ADDRESS_WIDTH);
+    this.memory = (configurations.CONTENT || '').parseBinary(
+      this.dataWidth,
+      2 ** this.addressWidth,
+    );
+
+    this.addInputPort('address', {
+      bits: this.addressWidth,
+      floating: 0,
+    });
+    this.addInputPort('select', { floating: 1 });
+    this.addOutputPort('data', { bits: this.dataWidth });
+  }
+
+  getMemory() {
+    return this.memory;
+  }
+
+  getAddress() {
+    if (!this.select) return 0;
+    return (this.currentAddress || 0).asNumber();
+  }
+
+  step(input) {
+    this.currentAddress = input.address;
+    this.select = input.select;
+
+    if (!input.select) return { data: 'x' };
+
+    return {
+      data: this.memory[input.address],
+    };
+  }
+}

--- a/packages/@logossim/components/Rom/RomRegister.js
+++ b/packages/@logossim/components/Rom/RomRegister.js
@@ -1,0 +1,74 @@
+import { Component } from '@logossim/core';
+
+import icon from './RomIcon';
+import model from './RomModel';
+import widget from './RomWidget';
+
+export default new Component({
+  type: 'Rom',
+  name: 'ROM',
+  description: 'Read only memory',
+  group: 'Memory',
+  configurations: [
+    {
+      name: 'DATA_WIDTH',
+      type: 'select',
+      default: '1',
+      label: 'Data width',
+      options: [
+        {
+          label: '1 bit',
+          value: '1',
+        },
+        {
+          label: '2 bits',
+          value: '2',
+        },
+        {
+          label: '4 bits',
+          value: '4',
+        },
+        {
+          label: '8 bits',
+          value: '8',
+        },
+        {
+          label: '16 bits',
+          value: '16',
+        },
+      ],
+    },
+    {
+      name: 'ADDRESS_WIDTH',
+      type: 'select',
+      default: '1',
+      label: 'Address width',
+      options: [
+        {
+          label: '1 bit',
+          value: '1',
+        },
+        {
+          label: '2 bits',
+          value: '2',
+        },
+        {
+          label: '4 bits',
+          value: '4',
+        },
+        {
+          label: '8 bits',
+          value: '8',
+        },
+      ],
+    },
+    {
+      name: 'CONTENT',
+      type: 'binary',
+      label: 'Initial content',
+    },
+  ],
+  model,
+  widget,
+  icon,
+});

--- a/packages/@logossim/components/Rom/RomWidget.jsx
+++ b/packages/@logossim/components/Rom/RomWidget.jsx
@@ -1,0 +1,140 @@
+import React from 'react';
+
+import { Port } from '@logossim/core';
+
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  position: relative;
+
+  width: 180px;
+  height: 150px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background: ${props =>
+    props.selected
+      ? 'var(--body-selected)'
+      : 'var(--body-unselected)'};
+  border: 1px solid
+    ${props =>
+      props.selected
+        ? 'var(--border-selected)'
+        : 'var(--border-unselected)'};
+
+  transition: 100ms linear;
+`;
+
+const Memory = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  overflow: hidden;
+  background: white;
+  border: 2px solid #c9c9c9;
+
+  width: 80%;
+  height: 112px;
+  font-size: 10px;
+`;
+
+const Cell = styled.div`
+  display: flex;
+  border-bottom: 1px solid #c9c9c9;
+  padding: 0 4px;
+`;
+
+const ActiveAddress = styled.div`
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 4px 0 4px 8px;
+  border-color: ${({ isSelected }) =>
+    `transparent transparent transparent ${
+      isSelected ? '#f44336' : 'transparent'
+    }`};
+  margin: auto 4px auto -4px;
+`;
+
+const AddressValueContainer = styled.div`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Address = styled.span`
+  margin-right: 4px;
+  padding: 1px 4px;
+  height: fit-content;
+
+  font-family: monospace;
+  font-size: 8px;
+  color: white;
+
+  background: #2642a0;
+  border-radius: 2px;
+`;
+
+const Value = styled.span`
+  padding: 4px;
+`;
+
+const PositionedPort = styled(Port)`
+  position: absolute;
+
+  ${props => {
+    if (props.name === 'select')
+      return 'bottom: -5px; right: calc(50% - 50px)';
+    if (props.name === 'address') return 'left: -5px';
+    if (props.name === 'data') return 'right: -5px';
+    return '';
+  }}
+`;
+
+const getMemoryDisplayRange = (memory, address) => {
+  if (address <= 1) return [0, 5];
+  if (address >= memory.length - 2)
+    return [memory.length - 5, memory.length];
+  return [address - 2, address + 3];
+};
+
+const RomWidget = props => {
+  const { model } = props;
+  const memory = model.getMemory();
+  const selectedAddress = model.getAddress();
+  const range = getMemoryDisplayRange(memory, selectedAddress);
+
+  return (
+    <Wrapper selected={model.isSelected()}>
+      <PositionedPort name="address" />
+      <PositionedPort name="data" />
+      <PositionedPort name="select" />
+
+      <Memory>
+        {memory.slice(...range).map((value, index) => {
+          const address = index + range[0];
+          const formattedAddress = `0x${address
+            .toString(16)
+            .padStart(2, '0')}`;
+
+          return (
+            <Cell key={formattedAddress}>
+              <ActiveAddress
+                isSelected={address === selectedAddress}
+              />
+              <AddressValueContainer>
+                <Address>{formattedAddress}</Address>
+                <Value isSelected>{value}</Value>
+              </AddressValueContainer>
+            </Cell>
+          );
+        })}
+      </Memory>
+    </Wrapper>
+  );
+};
+
+export default RomWidget;

--- a/packages/@logossim/components/Rom/__tests__/RomModel.test.js
+++ b/packages/@logossim/components/Rom/__tests__/RomModel.test.js
@@ -1,0 +1,93 @@
+import RomModel from '../RomModel';
+
+const { addPort } = global;
+
+beforeEach(() => {
+  const getPortSpy = jest.spyOn(RomModel.prototype, 'getPort');
+  getPortSpy.mockImplementation(() => ({
+    getWireValue: () => ({ asNumber: () => 5 }),
+  }));
+});
+
+it('should add ports on initialization', () => {
+  const addInputSpy = jest.spyOn(RomModel.prototype, 'addInputPort');
+  addInputSpy.mockImplementation(addPort);
+
+  const addOutputSpy = jest.spyOn(
+    RomModel.prototype,
+    'addOutputPort',
+  );
+  addOutputSpy.mockImplementation(addPort);
+
+  new RomModel({
+    DATA_WIDTH: 2,
+    ADDRESS_WIDTH: 4,
+  });
+
+  expect(addInputSpy).toHaveBeenCalledWith('address', {
+    bits: 4,
+    floating: 0,
+  });
+  expect(addInputSpy).toHaveBeenCalledWith('select', { floating: 1 });
+  expect(addOutputSpy).toHaveBeenCalledWith('data', { bits: 2 });
+});
+
+it('should be correctly initialized', () => {
+  const model = new RomModel({
+    DATA_WIDTH: 1,
+    ADDRESS_WIDTH: 8,
+  });
+  const memory = model.getMemory();
+
+  expect(memory).toHaveLength(256);
+  memory.forEach(value => expect(value).toEqual(0));
+});
+
+it('should be correcly initialized with content defined in configuration', () => {
+  const model = new RomModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+    CONTENT: '0001 0010 0100 1000',
+  });
+  const memory = model.getMemory();
+
+  expect(memory[0]).toEqual(1);
+  expect(memory[1]).toEqual(2);
+  expect(memory[2]).toEqual(4);
+  expect(memory[3]).toEqual(8);
+  expect(memory).toHaveLength(16);
+});
+
+it('should asynchronously output value of given address to the data port', () => {
+  const model = new RomModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+    CONTENT: '0001 0010 0100 1000',
+  });
+
+  [0, 1, 2, 3].forEach(address =>
+    expect(
+      model.step({
+        address,
+        select: 1,
+      }),
+    ).toEqual({ data: 2 ** address }),
+  );
+});
+
+it('should not output to data port if select is not set', () => {
+  const model = new RomModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+    CONTENT: '0001 0010 0100 1000',
+  });
+
+  [0, 1, 2, 3].forEach(address =>
+    expect(
+      model.step({
+        address,
+        select: 0,
+      }),
+    ).toEqual({ data: 'x' }),
+  );
+});

--- a/packages/@logossim/components/Rom/__tests__/RomModel.test.js
+++ b/packages/@logossim/components/Rom/__tests__/RomModel.test.js
@@ -2,92 +2,99 @@ import RomModel from '../RomModel';
 
 const { addPort } = global;
 
-beforeEach(() => {
-  const getPortSpy = jest.spyOn(RomModel.prototype, 'getPort');
-  getPortSpy.mockImplementation(() => ({
-    getWireValue: () => ({ asNumber: () => 5 }),
-  }));
-});
-
-it('should add ports on initialization', () => {
-  const addInputSpy = jest.spyOn(RomModel.prototype, 'addInputPort');
-  addInputSpy.mockImplementation(addPort);
-
-  const addOutputSpy = jest.spyOn(
-    RomModel.prototype,
-    'addOutputPort',
-  );
-  addOutputSpy.mockImplementation(addPort);
-
-  new RomModel({
-    DATA_WIDTH: 2,
-    ADDRESS_WIDTH: 4,
+describe('RomModel', () => {
+  beforeEach(() => {
+    const getPortSpy = jest.spyOn(RomModel.prototype, 'getPort');
+    getPortSpy.mockImplementation(() => ({
+      getWireValue: () => ({ asNumber: () => 5 }),
+    }));
   });
 
-  expect(addInputSpy).toHaveBeenCalledWith('address', {
-    bits: 4,
-    floating: 0,
-  });
-  expect(addInputSpy).toHaveBeenCalledWith('select', { floating: 1 });
-  expect(addOutputSpy).toHaveBeenCalledWith('data', { bits: 2 });
-});
+  it('should add ports on initialization', () => {
+    const addInputSpy = jest.spyOn(
+      RomModel.prototype,
+      'addInputPort',
+    );
+    addInputSpy.mockImplementation(addPort);
 
-it('should be correctly initialized', () => {
-  const model = new RomModel({
-    DATA_WIDTH: 1,
-    ADDRESS_WIDTH: 8,
-  });
-  const memory = model.getMemory();
+    const addOutputSpy = jest.spyOn(
+      RomModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  expect(memory).toHaveLength(256);
-  memory.forEach(value => expect(value).toEqual(0));
-});
+    new RomModel({
+      DATA_WIDTH: 2,
+      ADDRESS_WIDTH: 4,
+    });
 
-it('should be correcly initialized with content defined in configuration', () => {
-  const model = new RomModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
-    CONTENT: '0001 0010 0100 1000',
-  });
-  const memory = model.getMemory();
-
-  expect(memory[0]).toEqual(1);
-  expect(memory[1]).toEqual(2);
-  expect(memory[2]).toEqual(4);
-  expect(memory[3]).toEqual(8);
-  expect(memory).toHaveLength(16);
-});
-
-it('should asynchronously output value of given address to the data port', () => {
-  const model = new RomModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
-    CONTENT: '0001 0010 0100 1000',
+    expect(addInputSpy).toHaveBeenCalledWith('address', {
+      bits: 4,
+      floating: 0,
+    });
+    expect(addInputSpy).toHaveBeenCalledWith('select', {
+      floating: 1,
+    });
+    expect(addOutputSpy).toHaveBeenCalledWith('data', { bits: 2 });
   });
 
-  [0, 1, 2, 3].forEach(address =>
-    expect(
-      model.step({
-        address,
-        select: 1,
-      }),
-    ).toEqual({ data: 2 ** address }),
-  );
-});
+  it('should be correctly initialized', () => {
+    const model = new RomModel({
+      DATA_WIDTH: 1,
+      ADDRESS_WIDTH: 8,
+    });
+    const memory = model.getMemory();
 
-it('should not output to data port if select is not set', () => {
-  const model = new RomModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
-    CONTENT: '0001 0010 0100 1000',
+    expect(memory).toHaveLength(256);
+    memory.forEach(value => expect(value).toEqual(0));
   });
 
-  [0, 1, 2, 3].forEach(address =>
-    expect(
-      model.step({
-        address,
-        select: 0,
-      }),
-    ).toEqual({ data: 'x' }),
-  );
+  it('should be correcly initialized with content defined in configuration', () => {
+    const model = new RomModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+      CONTENT: '0001 0010 0100 1000',
+    });
+    const memory = model.getMemory();
+
+    expect(memory[0]).toEqual(1);
+    expect(memory[1]).toEqual(2);
+    expect(memory[2]).toEqual(4);
+    expect(memory[3]).toEqual(8);
+    expect(memory).toHaveLength(16);
+  });
+
+  it('should asynchronously output value of given address to the data port', () => {
+    const model = new RomModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+      CONTENT: '0001 0010 0100 1000',
+    });
+
+    [0, 1, 2, 3].forEach(address =>
+      expect(
+        model.step({
+          address,
+          select: 1,
+        }),
+      ).toEqual({ data: 2 ** address }),
+    );
+  });
+
+  it('should not output to data port if select is not set', () => {
+    const model = new RomModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+      CONTENT: '0001 0010 0100 1000',
+    });
+
+    [0, 1, 2, 3].forEach(address =>
+      expect(
+        model.step({
+          address,
+          select: 0,
+        }),
+      ).toEqual({ data: 'x' }),
+    );
+  });
 });

--- a/packages/@logossim/components/Rom/__tests__/RomWidget.test.jsx
+++ b/packages/@logossim/components/Rom/__tests__/RomWidget.test.jsx
@@ -1,0 +1,219 @@
+import React from 'react';
+
+import { render } from '../../testUtils';
+import RomModel from '../RomModel';
+import RomWidget from '../RomWidget';
+
+it('should have 1 output port', () => {
+  const model = new RomModel({
+    DATA_WIDTH: 1,
+    ADDRESS_WIDTH: 8,
+  });
+
+  const { container } = render(<RomWidget model={model} />);
+
+  const data = container.querySelector('[data-name=data]');
+
+  expect(data).toBeTruthy();
+});
+
+it('should have the correct input ports', () => {
+  const model = new RomModel({
+    DATA_WIDTH: 1,
+    ADDRESS_WIDTH: 8,
+  });
+
+  const { container } = render(<RomWidget model={model} />);
+
+  const address = container.querySelector('[data-name=address]');
+  const select = container.querySelector('[data-name=select]');
+
+  expect(address).toBeTruthy();
+  expect(select).toBeTruthy();
+});
+
+it('should display the first 5 values for the first 3 addresses', () => {
+  const model = new RomModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+    CONTENT: '0001 0010 0100 1000 1111',
+  });
+  model.getAddress = () => 0;
+
+  const { getByText, rerender } = render(<RomWidget model={model} />);
+
+  expect(getByText('0x00')).toBeTruthy();
+  expect(getByText('0x00').nextSibling).toHaveTextContent(1);
+
+  expect(getByText('0x01')).toBeTruthy();
+  expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+
+  expect(getByText('0x02')).toBeTruthy();
+  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+
+  expect(getByText('0x03')).toBeTruthy();
+  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+  expect(getByText('0x04')).toBeTruthy();
+  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+
+  model.getAddress = () => 1;
+  rerender(<RomWidget model={model} />);
+
+  expect(getByText('0x00')).toBeTruthy();
+  expect(getByText('0x00').nextSibling).toHaveTextContent(1);
+
+  expect(getByText('0x01')).toBeTruthy();
+  expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+
+  expect(getByText('0x02')).toBeTruthy();
+  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+
+  expect(getByText('0x03')).toBeTruthy();
+  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+  expect(getByText('0x04')).toBeTruthy();
+  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+
+  model.getAddress = () => 2;
+  rerender(<RomWidget model={model} />);
+
+  expect(getByText('0x00')).toBeTruthy();
+  expect(getByText('0x00').nextSibling).toHaveTextContent(1);
+
+  expect(getByText('0x01')).toBeTruthy();
+  expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+
+  expect(getByText('0x02')).toBeTruthy();
+  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+
+  expect(getByText('0x03')).toBeTruthy();
+  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+  expect(getByText('0x04')).toBeTruthy();
+  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+});
+
+it('should display the adjacent values for addresses in the middle', () => {
+  const model = new RomModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+    CONTENT: '0001 0010 0100 1000 1111',
+  });
+  model.getAddress = () => 3;
+
+  const { getByText, rerender } = render(<RomWidget model={model} />);
+
+  expect(getByText('0x01')).toBeTruthy();
+  expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+
+  expect(getByText('0x02')).toBeTruthy();
+  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+
+  expect(getByText('0x03')).toBeTruthy();
+  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+  expect(getByText('0x04')).toBeTruthy();
+  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+
+  expect(getByText('0x05')).toBeTruthy();
+  expect(getByText('0x05').nextSibling).toHaveTextContent(0);
+
+  model.getAddress = () => 4;
+  rerender(<RomWidget model={model} />);
+
+  expect(getByText('0x02')).toBeTruthy();
+  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+
+  expect(getByText('0x03')).toBeTruthy();
+  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+  expect(getByText('0x04')).toBeTruthy();
+  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+
+  expect(getByText('0x05')).toBeTruthy();
+  expect(getByText('0x05').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x06')).toBeTruthy();
+  expect(getByText('0x06').nextSibling).toHaveTextContent(0);
+
+  model.getAddress = () => 5;
+  rerender(<RomWidget model={model} />);
+
+  expect(getByText('0x03')).toBeTruthy();
+  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+  expect(getByText('0x04')).toBeTruthy();
+  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+
+  expect(getByText('0x05')).toBeTruthy();
+  expect(getByText('0x05').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x06')).toBeTruthy();
+  expect(getByText('0x06').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x07')).toBeTruthy();
+  expect(getByText('0x07').nextSibling).toHaveTextContent(0);
+});
+
+it('should display the last 5 values for the last 3 addresses', () => {
+  const model = new RomModel({
+    DATA_WIDTH: 4,
+    ADDRESS_WIDTH: 4,
+    CONTENT: '0001 0010 0100 1000 1111',
+  });
+  model.getAddress = () => 13;
+
+  const { getByText, rerender } = render(<RomWidget model={model} />);
+
+  expect(getByText('0x0b')).toBeTruthy();
+  expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0c')).toBeTruthy();
+  expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0d')).toBeTruthy();
+  expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0e')).toBeTruthy();
+  expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0f')).toBeTruthy();
+  expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
+
+  model.getAddress = () => 14;
+  rerender(<RomWidget model={model} />);
+
+  expect(getByText('0x0b')).toBeTruthy();
+  expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0c')).toBeTruthy();
+  expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0d')).toBeTruthy();
+  expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0e')).toBeTruthy();
+  expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0f')).toBeTruthy();
+  expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
+
+  model.getAddress = () => 15;
+  rerender(<RomWidget model={model} />);
+
+  expect(getByText('0x0b')).toBeTruthy();
+  expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0c')).toBeTruthy();
+  expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0d')).toBeTruthy();
+  expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0e')).toBeTruthy();
+  expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
+
+  expect(getByText('0x0f')).toBeTruthy();
+  expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
+});

--- a/packages/@logossim/components/Rom/__tests__/RomWidget.test.jsx
+++ b/packages/@logossim/components/Rom/__tests__/RomWidget.test.jsx
@@ -4,216 +4,224 @@ import { render } from '../../testUtils';
 import RomModel from '../RomModel';
 import RomWidget from '../RomWidget';
 
-it('should have 1 output port', () => {
-  const model = new RomModel({
-    DATA_WIDTH: 1,
-    ADDRESS_WIDTH: 8,
+describe('RomWidget', () => {
+  it('should have 1 output port', () => {
+    const model = new RomModel({
+      DATA_WIDTH: 1,
+      ADDRESS_WIDTH: 8,
+    });
+
+    const { container } = render(<RomWidget model={model} />);
+
+    const data = container.querySelector('[data-name=data]');
+
+    expect(data).toBeTruthy();
   });
 
-  const { container } = render(<RomWidget model={model} />);
+  it('should have the correct input ports', () => {
+    const model = new RomModel({
+      DATA_WIDTH: 1,
+      ADDRESS_WIDTH: 8,
+    });
 
-  const data = container.querySelector('[data-name=data]');
+    const { container } = render(<RomWidget model={model} />);
 
-  expect(data).toBeTruthy();
-});
+    const address = container.querySelector('[data-name=address]');
+    const select = container.querySelector('[data-name=select]');
 
-it('should have the correct input ports', () => {
-  const model = new RomModel({
-    DATA_WIDTH: 1,
-    ADDRESS_WIDTH: 8,
+    expect(address).toBeTruthy();
+    expect(select).toBeTruthy();
   });
 
-  const { container } = render(<RomWidget model={model} />);
+  it('should display the first 5 values for the first 3 addresses', () => {
+    const model = new RomModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+      CONTENT: '0001 0010 0100 1000 1111',
+    });
+    model.getAddress = () => 0;
 
-  const address = container.querySelector('[data-name=address]');
-  const select = container.querySelector('[data-name=select]');
+    const { getByText, rerender } = render(
+      <RomWidget model={model} />,
+    );
 
-  expect(address).toBeTruthy();
-  expect(select).toBeTruthy();
-});
+    expect(getByText('0x00')).toBeTruthy();
+    expect(getByText('0x00').nextSibling).toHaveTextContent(1);
 
-it('should display the first 5 values for the first 3 addresses', () => {
-  const model = new RomModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
-    CONTENT: '0001 0010 0100 1000 1111',
+    expect(getByText('0x01')).toBeTruthy();
+    expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+
+    expect(getByText('0x02')).toBeTruthy();
+    expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+
+    expect(getByText('0x03')).toBeTruthy();
+    expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+    expect(getByText('0x04')).toBeTruthy();
+    expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+
+    model.getAddress = () => 1;
+    rerender(<RomWidget model={model} />);
+
+    expect(getByText('0x00')).toBeTruthy();
+    expect(getByText('0x00').nextSibling).toHaveTextContent(1);
+
+    expect(getByText('0x01')).toBeTruthy();
+    expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+
+    expect(getByText('0x02')).toBeTruthy();
+    expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+
+    expect(getByText('0x03')).toBeTruthy();
+    expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+    expect(getByText('0x04')).toBeTruthy();
+    expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+
+    model.getAddress = () => 2;
+    rerender(<RomWidget model={model} />);
+
+    expect(getByText('0x00')).toBeTruthy();
+    expect(getByText('0x00').nextSibling).toHaveTextContent(1);
+
+    expect(getByText('0x01')).toBeTruthy();
+    expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+
+    expect(getByText('0x02')).toBeTruthy();
+    expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+
+    expect(getByText('0x03')).toBeTruthy();
+    expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+
+    expect(getByText('0x04')).toBeTruthy();
+    expect(getByText('0x04').nextSibling).toHaveTextContent(15);
   });
-  model.getAddress = () => 0;
 
-  const { getByText, rerender } = render(<RomWidget model={model} />);
+  it('should display the adjacent values for addresses in the middle', () => {
+    const model = new RomModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+      CONTENT: '0001 0010 0100 1000 1111',
+    });
+    model.getAddress = () => 3;
 
-  expect(getByText('0x00')).toBeTruthy();
-  expect(getByText('0x00').nextSibling).toHaveTextContent(1);
+    const { getByText, rerender } = render(
+      <RomWidget model={model} />,
+    );
 
-  expect(getByText('0x01')).toBeTruthy();
-  expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+    expect(getByText('0x01')).toBeTruthy();
+    expect(getByText('0x01').nextSibling).toHaveTextContent(2);
 
-  expect(getByText('0x02')).toBeTruthy();
-  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+    expect(getByText('0x02')).toBeTruthy();
+    expect(getByText('0x02').nextSibling).toHaveTextContent(4);
 
-  expect(getByText('0x03')).toBeTruthy();
-  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+    expect(getByText('0x03')).toBeTruthy();
+    expect(getByText('0x03').nextSibling).toHaveTextContent(8);
 
-  expect(getByText('0x04')).toBeTruthy();
-  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+    expect(getByText('0x04')).toBeTruthy();
+    expect(getByText('0x04').nextSibling).toHaveTextContent(15);
 
-  model.getAddress = () => 1;
-  rerender(<RomWidget model={model} />);
+    expect(getByText('0x05')).toBeTruthy();
+    expect(getByText('0x05').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x00')).toBeTruthy();
-  expect(getByText('0x00').nextSibling).toHaveTextContent(1);
+    model.getAddress = () => 4;
+    rerender(<RomWidget model={model} />);
 
-  expect(getByText('0x01')).toBeTruthy();
-  expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+    expect(getByText('0x02')).toBeTruthy();
+    expect(getByText('0x02').nextSibling).toHaveTextContent(4);
 
-  expect(getByText('0x02')).toBeTruthy();
-  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+    expect(getByText('0x03')).toBeTruthy();
+    expect(getByText('0x03').nextSibling).toHaveTextContent(8);
 
-  expect(getByText('0x03')).toBeTruthy();
-  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+    expect(getByText('0x04')).toBeTruthy();
+    expect(getByText('0x04').nextSibling).toHaveTextContent(15);
 
-  expect(getByText('0x04')).toBeTruthy();
-  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+    expect(getByText('0x05')).toBeTruthy();
+    expect(getByText('0x05').nextSibling).toHaveTextContent(0);
 
-  model.getAddress = () => 2;
-  rerender(<RomWidget model={model} />);
+    expect(getByText('0x06')).toBeTruthy();
+    expect(getByText('0x06').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x00')).toBeTruthy();
-  expect(getByText('0x00').nextSibling).toHaveTextContent(1);
+    model.getAddress = () => 5;
+    rerender(<RomWidget model={model} />);
 
-  expect(getByText('0x01')).toBeTruthy();
-  expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+    expect(getByText('0x03')).toBeTruthy();
+    expect(getByText('0x03').nextSibling).toHaveTextContent(8);
 
-  expect(getByText('0x02')).toBeTruthy();
-  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+    expect(getByText('0x04')).toBeTruthy();
+    expect(getByText('0x04').nextSibling).toHaveTextContent(15);
 
-  expect(getByText('0x03')).toBeTruthy();
-  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+    expect(getByText('0x05')).toBeTruthy();
+    expect(getByText('0x05').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x04')).toBeTruthy();
-  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
-});
+    expect(getByText('0x06')).toBeTruthy();
+    expect(getByText('0x06').nextSibling).toHaveTextContent(0);
 
-it('should display the adjacent values for addresses in the middle', () => {
-  const model = new RomModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
-    CONTENT: '0001 0010 0100 1000 1111',
+    expect(getByText('0x07')).toBeTruthy();
+    expect(getByText('0x07').nextSibling).toHaveTextContent(0);
   });
-  model.getAddress = () => 3;
 
-  const { getByText, rerender } = render(<RomWidget model={model} />);
+  it('should display the last 5 values for the last 3 addresses', () => {
+    const model = new RomModel({
+      DATA_WIDTH: 4,
+      ADDRESS_WIDTH: 4,
+      CONTENT: '0001 0010 0100 1000 1111',
+    });
+    model.getAddress = () => 13;
 
-  expect(getByText('0x01')).toBeTruthy();
-  expect(getByText('0x01').nextSibling).toHaveTextContent(2);
+    const { getByText, rerender } = render(
+      <RomWidget model={model} />,
+    );
 
-  expect(getByText('0x02')).toBeTruthy();
-  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+    expect(getByText('0x0b')).toBeTruthy();
+    expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x03')).toBeTruthy();
-  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+    expect(getByText('0x0c')).toBeTruthy();
+    expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x04')).toBeTruthy();
-  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+    expect(getByText('0x0d')).toBeTruthy();
+    expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x05')).toBeTruthy();
-  expect(getByText('0x05').nextSibling).toHaveTextContent(0);
+    expect(getByText('0x0e')).toBeTruthy();
+    expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
 
-  model.getAddress = () => 4;
-  rerender(<RomWidget model={model} />);
+    expect(getByText('0x0f')).toBeTruthy();
+    expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x02')).toBeTruthy();
-  expect(getByText('0x02').nextSibling).toHaveTextContent(4);
+    model.getAddress = () => 14;
+    rerender(<RomWidget model={model} />);
 
-  expect(getByText('0x03')).toBeTruthy();
-  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+    expect(getByText('0x0b')).toBeTruthy();
+    expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x04')).toBeTruthy();
-  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+    expect(getByText('0x0c')).toBeTruthy();
+    expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x05')).toBeTruthy();
-  expect(getByText('0x05').nextSibling).toHaveTextContent(0);
+    expect(getByText('0x0d')).toBeTruthy();
+    expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x06')).toBeTruthy();
-  expect(getByText('0x06').nextSibling).toHaveTextContent(0);
+    expect(getByText('0x0e')).toBeTruthy();
+    expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
 
-  model.getAddress = () => 5;
-  rerender(<RomWidget model={model} />);
+    expect(getByText('0x0f')).toBeTruthy();
+    expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x03')).toBeTruthy();
-  expect(getByText('0x03').nextSibling).toHaveTextContent(8);
+    model.getAddress = () => 15;
+    rerender(<RomWidget model={model} />);
 
-  expect(getByText('0x04')).toBeTruthy();
-  expect(getByText('0x04').nextSibling).toHaveTextContent(15);
+    expect(getByText('0x0b')).toBeTruthy();
+    expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x05')).toBeTruthy();
-  expect(getByText('0x05').nextSibling).toHaveTextContent(0);
+    expect(getByText('0x0c')).toBeTruthy();
+    expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x06')).toBeTruthy();
-  expect(getByText('0x06').nextSibling).toHaveTextContent(0);
+    expect(getByText('0x0d')).toBeTruthy();
+    expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
 
-  expect(getByText('0x07')).toBeTruthy();
-  expect(getByText('0x07').nextSibling).toHaveTextContent(0);
-});
+    expect(getByText('0x0e')).toBeTruthy();
+    expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
 
-it('should display the last 5 values for the last 3 addresses', () => {
-  const model = new RomModel({
-    DATA_WIDTH: 4,
-    ADDRESS_WIDTH: 4,
-    CONTENT: '0001 0010 0100 1000 1111',
+    expect(getByText('0x0f')).toBeTruthy();
+    expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
   });
-  model.getAddress = () => 13;
-
-  const { getByText, rerender } = render(<RomWidget model={model} />);
-
-  expect(getByText('0x0b')).toBeTruthy();
-  expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0c')).toBeTruthy();
-  expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0d')).toBeTruthy();
-  expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0e')).toBeTruthy();
-  expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0f')).toBeTruthy();
-  expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
-
-  model.getAddress = () => 14;
-  rerender(<RomWidget model={model} />);
-
-  expect(getByText('0x0b')).toBeTruthy();
-  expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0c')).toBeTruthy();
-  expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0d')).toBeTruthy();
-  expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0e')).toBeTruthy();
-  expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0f')).toBeTruthy();
-  expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
-
-  model.getAddress = () => 15;
-  rerender(<RomWidget model={model} />);
-
-  expect(getByText('0x0b')).toBeTruthy();
-  expect(getByText('0x0b').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0c')).toBeTruthy();
-  expect(getByText('0x0c').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0d')).toBeTruthy();
-  expect(getByText('0x0d').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0e')).toBeTruthy();
-  expect(getByText('0x0e').nextSibling).toHaveTextContent(0);
-
-  expect(getByText('0x0f')).toBeTruthy();
-  expect(getByText('0x0f').nextSibling).toHaveTextContent(0);
 });

--- a/packages/@logossim/components/Splitter/SplitterModel.js
+++ b/packages/@logossim/components/Splitter/SplitterModel.js
@@ -4,7 +4,7 @@ export default class SplitterModel extends BaseModel {
   initialize(configurations) {
     this.bits = Number(configurations.DATA_BITS);
 
-    this.addInputPort('in', this.bits);
+    this.addInputPort('in', { bits: this.bits });
     for (let i = 0; i < this.bits; i += 1) {
       this.addOutputPort(`out${i}`);
     }

--- a/packages/@logossim/components/Splitter/SplitterWidget.jsx
+++ b/packages/@logossim/components/Splitter/SplitterWidget.jsx
@@ -64,12 +64,11 @@ const SplitterWidget = props => {
 
   return (
     <Wrapper dataBits={dataBits}>
-      <PositionedPort name="in" model={model} />
+      <PositionedPort name="in" />
       {outputPorts.map((port, i) => (
         <PositionedPort
           key={port.getName()}
           name={port.getName()}
-          model={model}
           position={(i + 1) * 15}
         />
       ))}

--- a/packages/@logossim/components/Splitter/SplitterWidget.jsx
+++ b/packages/@logossim/components/Splitter/SplitterWidget.jsx
@@ -64,18 +64,12 @@ const SplitterWidget = props => {
 
   return (
     <Wrapper dataBits={dataBits}>
-      <PositionedPort
-        name="in"
-        model={model}
-        port={model.getPort('in')}
-        engine={engine}
-      />
+      <PositionedPort name="in" model={model} engine={engine} />
       {outputPorts.map((port, i) => (
         <PositionedPort
           key={port.getName()}
           name={port.getName()}
           model={model}
-          port={port}
           engine={engine}
           position={(i + 1) * 15}
         />

--- a/packages/@logossim/components/Splitter/SplitterWidget.jsx
+++ b/packages/@logossim/components/Splitter/SplitterWidget.jsx
@@ -53,7 +53,7 @@ export const Shape = ({ selected, dataBits }) => {
 };
 
 const SplitterWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
     configurations: { DATA_BITS },
@@ -64,13 +64,12 @@ const SplitterWidget = props => {
 
   return (
     <Wrapper dataBits={dataBits}>
-      <PositionedPort name="in" model={model} engine={engine} />
+      <PositionedPort name="in" model={model} />
       {outputPorts.map((port, i) => (
         <PositionedPort
           key={port.getName()}
           name={port.getName()}
           model={model}
-          engine={engine}
           position={(i + 1) * 15}
         />
       ))}

--- a/packages/@logossim/components/Splitter/__tests__/SplitterModel.test.js
+++ b/packages/@logossim/components/Splitter/__tests__/SplitterModel.test.js
@@ -31,26 +31,26 @@ it('should correctly split the input value', () => {
   });
 
   expect(
-    model.stepAndMask({
+    model.step({
       in: 0b1010_0101_1111_0000,
     }),
   ).toEqual({
-    out0: [0],
-    out1: [0],
-    out2: [0],
-    out3: [0],
-    out4: [1],
-    out5: [1],
-    out6: [1],
-    out7: [1],
-    out8: [1],
-    out9: [0],
-    out10: [1],
-    out11: [0],
-    out12: [0],
-    out13: [1],
-    out14: [0],
-    out15: [1],
+    out0: 0,
+    out1: 0,
+    out2: 0,
+    out3: 0,
+    out4: 1,
+    out5: 1,
+    out6: 1,
+    out7: 1,
+    out8: 1,
+    out9: 0,
+    out10: 1,
+    out11: 0,
+    out12: 0,
+    out13: 1,
+    out14: 0,
+    out15: 1,
   });
 });
 

--- a/packages/@logossim/components/Splitter/__tests__/SplitterModel.test.js
+++ b/packages/@logossim/components/Splitter/__tests__/SplitterModel.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import SplitterModel from '../SplitterModel';
 
 const { addPort } = global;

--- a/packages/@logossim/components/Splitter/__tests__/SplitterModel.test.js
+++ b/packages/@logossim/components/Splitter/__tests__/SplitterModel.test.js
@@ -20,7 +20,7 @@ it('should add ports on initialization', () => {
     DATA_BITS: 16,
   });
 
-  expect(addInputSpy).toHaveBeenCalledWith('in', 16);
+  expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 16 });
   [...Array(16).keys()].forEach(i => {
     expect(addOutputSpy).toHaveBeenNthCalledWith(i + 1, `out${i}`);
   });

--- a/packages/@logossim/components/Splitter/__tests__/SplitterModel.test.js
+++ b/packages/@logossim/components/Splitter/__tests__/SplitterModel.test.js
@@ -2,84 +2,86 @@ import SplitterModel from '../SplitterModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const addInputSpy = jest.spyOn(
-    SplitterModel.prototype,
-    'addInputPort',
-  );
-  addInputSpy.mockImplementation(addPort);
+describe('SplitterModel', () => {
+  it('should add ports on initialization', () => {
+    const addInputSpy = jest.spyOn(
+      SplitterModel.prototype,
+      'addInputPort',
+    );
+    addInputSpy.mockImplementation(addPort);
 
-  const addOutputSpy = jest.spyOn(
-    SplitterModel.prototype,
-    'addOutputPort',
-  );
-  addOutputSpy.mockImplementation(addPort);
+    const addOutputSpy = jest.spyOn(
+      SplitterModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  new SplitterModel({
-    DATA_BITS: 16,
+    new SplitterModel({
+      DATA_BITS: 16,
+    });
+
+    expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 16 });
+    [...Array(16).keys()].forEach(i => {
+      expect(addOutputSpy).toHaveBeenNthCalledWith(i + 1, `out${i}`);
+    });
   });
 
-  expect(addInputSpy).toHaveBeenCalledWith('in', { bits: 16 });
-  [...Array(16).keys()].forEach(i => {
-    expect(addOutputSpy).toHaveBeenNthCalledWith(i + 1, `out${i}`);
-  });
-});
+  it('should correctly split the input value', () => {
+    const model = new SplitterModel({
+      DATA_BITS: 16,
+    });
 
-it('should correctly split the input value', () => {
-  const model = new SplitterModel({
-    DATA_BITS: 16,
-  });
-
-  expect(
-    model.step({
-      in: 0b1010_0101_1111_0000,
-    }),
-  ).toEqual({
-    out0: 0,
-    out1: 0,
-    out2: 0,
-    out3: 0,
-    out4: 1,
-    out5: 1,
-    out6: 1,
-    out7: 1,
-    out8: 1,
-    out9: 0,
-    out10: 1,
-    out11: 0,
-    out12: 0,
-    out13: 1,
-    out14: 0,
-    out15: 1,
-  });
-});
-
-it('should correctly split having floating values', () => {
-  const model = new SplitterModel({
-    DATA_BITS: 2,
+    expect(
+      model.step({
+        in: 0b1010_0101_1111_0000,
+      }),
+    ).toEqual({
+      out0: 0,
+      out1: 0,
+      out2: 0,
+      out3: 0,
+      out4: 1,
+      out5: 1,
+      out6: 1,
+      out7: 1,
+      out8: 1,
+      out9: 0,
+      out10: 1,
+      out11: 0,
+      out12: 0,
+      out13: 1,
+      out14: 0,
+      out15: 1,
+    });
   });
 
-  expect(
-    model.stepFloating({
-      in: [0, 'x'],
-    }),
-  ).toEqual({
-    out0: ['x'],
-    out1: [0],
-  });
-});
+  it('should correctly split having floating values', () => {
+    const model = new SplitterModel({
+      DATA_BITS: 2,
+    });
 
-it('should correctly split having error values', () => {
-  const model = new SplitterModel({
-    DATA_BITS: 2,
+    expect(
+      model.stepFloating({
+        in: [0, 'x'],
+      }),
+    ).toEqual({
+      out0: ['x'],
+      out1: [0],
+    });
   });
 
-  expect(
-    model.stepFloating({
-      in: [0, 'e'],
-    }),
-  ).toEqual({
-    out0: ['e'],
-    out1: [0],
+  it('should correctly split having error values', () => {
+    const model = new SplitterModel({
+      DATA_BITS: 2,
+    });
+
+    expect(
+      model.stepFloating({
+        in: [0, 'e'],
+      }),
+    ).toEqual({
+      out0: ['e'],
+      out1: [0],
+    });
   });
 });

--- a/packages/@logossim/components/Splitter/__tests__/SplitterWidget.test.jsx
+++ b/packages/@logossim/components/Splitter/__tests__/SplitterWidget.test.jsx
@@ -4,24 +4,26 @@ import { render } from '../../testUtils';
 import SplitterModel from '../SplitterModel';
 import SplitterWidget from '../SplitterWidget';
 
-it('should have 1 input port', () => {
-  const model = new SplitterModel({
-    DATA_BITS: 16,
+describe('SplitterWidget', () => {
+  it('should have 1 input port', () => {
+    const model = new SplitterModel({
+      DATA_BITS: 16,
+    });
+
+    const { container } = render(<SplitterWidget model={model} />);
+
+    const ports = container.querySelectorAll('[data-name=in]');
+    expect(ports).toHaveLength(1);
   });
 
-  const { container } = render(<SplitterWidget model={model} />);
+  it('should have the amount of output ports determined by configuration', () => {
+    const model = new SplitterModel({
+      DATA_BITS: 16,
+    });
 
-  const ports = container.querySelectorAll('[data-name=in]');
-  expect(ports).toHaveLength(1);
-});
+    const { container } = render(<SplitterWidget model={model} />);
 
-it('should have the amount of output ports determined by configuration', () => {
-  const model = new SplitterModel({
-    DATA_BITS: 16,
+    const ports = container.querySelectorAll('[data-name^=out]');
+    expect(ports).toHaveLength(16);
   });
-
-  const { container } = render(<SplitterWidget model={model} />);
-
-  const ports = container.querySelectorAll('[data-name^=out]');
-  expect(ports).toHaveLength(16);
 });

--- a/packages/@logossim/components/Splitter/__tests__/SplitterWidget.test.jsx
+++ b/packages/@logossim/components/Splitter/__tests__/SplitterWidget.test.jsx
@@ -1,20 +1,15 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import SplitterModel from '../SplitterModel';
 import SplitterWidget from '../SplitterWidget';
-
-const { engine } = global;
 
 it('should have 1 input port', () => {
   const model = new SplitterModel({
     DATA_BITS: 16,
   });
 
-  const { container } = render(
-    <SplitterWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<SplitterWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name=in]');
   expect(ports).toHaveLength(1);
@@ -25,9 +20,7 @@ it('should have the amount of output ports determined by configuration', () => {
     DATA_BITS: 16,
   });
 
-  const { container } = render(
-    <SplitterWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<SplitterWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name^=out]');
   expect(ports).toHaveLength(16);

--- a/packages/@logossim/components/Ssd/SsdModel.js
+++ b/packages/@logossim/components/Ssd/SsdModel.js
@@ -8,14 +8,14 @@ export default class LedModel extends BaseModel {
       off: configurations.OFF_COLOR,
     };
 
-    this.addInputPort('a');
-    this.addInputPort('b');
-    this.addInputPort('c');
-    this.addInputPort('d');
-    this.addInputPort('e');
-    this.addInputPort('f');
-    this.addInputPort('g');
-    this.addInputPort('dp');
+    this.addInputPort('a', { floating: 0, error: 0 });
+    this.addInputPort('b', { floating: 0, error: 0 });
+    this.addInputPort('c', { floating: 0, error: 0 });
+    this.addInputPort('d', { floating: 0, error: 0 });
+    this.addInputPort('e', { floating: 0, error: 0 });
+    this.addInputPort('f', { floating: 0, error: 0 });
+    this.addInputPort('g', { floating: 0, error: 0 });
+    this.addInputPort('dp', { floating: 0, error: 0 });
   }
 
   getInput(segment) {

--- a/packages/@logossim/components/Ssd/SsdRegister.js
+++ b/packages/@logossim/components/Ssd/SsdRegister.js
@@ -57,28 +57,28 @@ export default new Component({
     {
       name: 'OFF_COLOR',
       type: 'select',
-      default: '#000000',
+      default: '#00000040',
       label: 'Off color',
       options: [
         {
           label: 'Red',
-          value: '#ff0000',
+          value: '#ff000040',
         },
         {
           label: 'Green',
-          value: '#00ff00',
+          value: '#00ff0040',
         },
         {
           label: 'Blue',
-          value: '#0000ff',
+          value: '#0000ff40',
         },
         {
           label: 'White',
-          value: '#ffffff',
+          value: '#ffffff40',
         },
         {
           label: 'Black',
-          value: '#000000',
+          value: '#00000040',
         },
       ],
     },

--- a/packages/@logossim/components/Ssd/SsdWidget.jsx
+++ b/packages/@logossim/components/Ssd/SsdWidget.jsx
@@ -43,47 +43,51 @@ export const Shape = ({ segments, selected, icon }) => (
     strokeWidth="2"
     strokeLinecap="round"
     strokeLinejoin="round"
+    style={{
+      opacity: selected ? '80' : 'ff',
+      fillOpacity: selected ? '80' : 'ff',
+    }}
   >
     {/* A */}
     <polyline
       points="5 18 11 20 32 20 35 14 9 14"
-      fill={`${segments.a}${selected ? '80' : 'ff'}`}
+      fill={segments.a}
       data-testid="a"
     />
     {/* B */}
     <polyline
       points="37 14 41 20 39 42 37 44 33 39 34 20"
-      fill={`${segments.b}${selected ? '80' : 'ff'}`}
+      fill={segments.b}
       data-testid="b"
     />
     {/* C */}
     <polyline
       points="37 46 38 47 36 71 31 76 29 69 31 51"
-      fill={`${segments.c}${selected ? '80' : 'ff'}`}
+      fill={segments.c}
       data-testid="c"
     />
     {/* D */}
     <polyline
       points="0 72 7 69 27 69 29 76 4 76"
-      fill={`${segments.d}${selected ? '80' : 'ff'}`}
+      fill={segments.d}
       data-testid="d"
     />
     {/* E */}
     <polyline
       points="4 46 8 51 7 67 0 70 2 47"
-      fill={`${segments.e}${selected ? '80' : 'ff'}`}
+      fill={segments.e}
       data-testid="e"
     />
     {/* F */}
     <polyline
       points="5 20 11 22 10 39 4 44 3 42"
-      fill={`${segments.f}${selected ? '80' : 'ff'}`}
+      fill={segments.f}
       data-testid="f"
     />
     {/* G */}
     <polyline
       points="6 45 9 48 31 48 35 45 32 41 11 41"
-      fill={`${segments.g}${selected ? '80' : 'ff'}`}
+      fill={segments.g}
       data-testid="g"
     />
     {/* DP */}
@@ -91,7 +95,7 @@ export const Shape = ({ segments, selected, icon }) => (
       r="5"
       cx="45"
       cy="71"
-      fill={`${segments.dp}${selected ? '80' : 'ff'}`}
+      fill={segments.dp}
       data-testid="dp"
     />
   </svg>

--- a/packages/@logossim/components/Ssd/SsdWidget.jsx
+++ b/packages/@logossim/components/Ssd/SsdWidget.jsx
@@ -121,7 +121,6 @@ const LedWidget = props => {
           name={segment}
           model={model}
           position={model.getPositionForSegment(segment)}
-          port={model.getPort(segment)}
           engine={engine}
         />
       ))}

--- a/packages/@logossim/components/Ssd/SsdWidget.jsx
+++ b/packages/@logossim/components/Ssd/SsdWidget.jsx
@@ -98,7 +98,7 @@ export const Shape = ({ segments, selected, icon }) => (
 );
 
 const LedWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
   } = model;
@@ -121,7 +121,6 @@ const LedWidget = props => {
           name={segment}
           model={model}
           position={model.getPositionForSegment(segment)}
-          engine={engine}
         />
       ))}
     </Wrapper>

--- a/packages/@logossim/components/Ssd/SsdWidget.jsx
+++ b/packages/@logossim/components/Ssd/SsdWidget.jsx
@@ -119,7 +119,6 @@ const LedWidget = props => {
         <PositionedPort
           key={segment}
           name={segment}
-          model={model}
           position={model.getPositionForSegment(segment)}
         />
       ))}

--- a/packages/@logossim/components/Ssd/__tests__/SsdModel.test.js
+++ b/packages/@logossim/components/Ssd/__tests__/SsdModel.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import SsdModel from '../SsdModel';
 
 const { addPort } = global;
@@ -9,12 +8,12 @@ it('should add ports on initialization', () => {
 
   new SsdModel();
 
-  expect(spy).toHaveBeenCalledWith('a');
-  expect(spy).toHaveBeenCalledWith('b');
-  expect(spy).toHaveBeenCalledWith('c');
-  expect(spy).toHaveBeenCalledWith('d');
-  expect(spy).toHaveBeenCalledWith('e');
-  expect(spy).toHaveBeenCalledWith('f');
-  expect(spy).toHaveBeenCalledWith('g');
-  expect(spy).toHaveBeenCalledWith('dp');
+  expect(spy).toHaveBeenCalledWith('a', { error: 0, floating: 0 });
+  expect(spy).toHaveBeenCalledWith('b', { error: 0, floating: 0 });
+  expect(spy).toHaveBeenCalledWith('c', { error: 0, floating: 0 });
+  expect(spy).toHaveBeenCalledWith('d', { error: 0, floating: 0 });
+  expect(spy).toHaveBeenCalledWith('e', { error: 0, floating: 0 });
+  expect(spy).toHaveBeenCalledWith('f', { error: 0, floating: 0 });
+  expect(spy).toHaveBeenCalledWith('g', { error: 0, floating: 0 });
+  expect(spy).toHaveBeenCalledWith('dp', { error: 0, floating: 0 });
 });

--- a/packages/@logossim/components/Ssd/__tests__/SsdModel.test.js
+++ b/packages/@logossim/components/Ssd/__tests__/SsdModel.test.js
@@ -2,18 +2,20 @@ import SsdModel from '../SsdModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const spy = jest.spyOn(SsdModel.prototype, 'addInputPort');
-  spy.mockImplementation(addPort);
+describe('SsdModel', () => {
+  it('should add ports on initialization', () => {
+    const spy = jest.spyOn(SsdModel.prototype, 'addInputPort');
+    spy.mockImplementation(addPort);
 
-  new SsdModel();
+    new SsdModel();
 
-  expect(spy).toHaveBeenCalledWith('a', { error: 0, floating: 0 });
-  expect(spy).toHaveBeenCalledWith('b', { error: 0, floating: 0 });
-  expect(spy).toHaveBeenCalledWith('c', { error: 0, floating: 0 });
-  expect(spy).toHaveBeenCalledWith('d', { error: 0, floating: 0 });
-  expect(spy).toHaveBeenCalledWith('e', { error: 0, floating: 0 });
-  expect(spy).toHaveBeenCalledWith('f', { error: 0, floating: 0 });
-  expect(spy).toHaveBeenCalledWith('g', { error: 0, floating: 0 });
-  expect(spy).toHaveBeenCalledWith('dp', { error: 0, floating: 0 });
+    expect(spy).toHaveBeenCalledWith('a', { error: 0, floating: 0 });
+    expect(spy).toHaveBeenCalledWith('b', { error: 0, floating: 0 });
+    expect(spy).toHaveBeenCalledWith('c', { error: 0, floating: 0 });
+    expect(spy).toHaveBeenCalledWith('d', { error: 0, floating: 0 });
+    expect(spy).toHaveBeenCalledWith('e', { error: 0, floating: 0 });
+    expect(spy).toHaveBeenCalledWith('f', { error: 0, floating: 0 });
+    expect(spy).toHaveBeenCalledWith('g', { error: 0, floating: 0 });
+    expect(spy).toHaveBeenCalledWith('dp', { error: 0, floating: 0 });
+  });
 });

--- a/packages/@logossim/components/Ssd/__tests__/SsdWidget.test.jsx
+++ b/packages/@logossim/components/Ssd/__tests__/SsdWidget.test.jsx
@@ -54,14 +54,14 @@ it('should turn on the correct display segments when configured with active on h
   const g = getByTestId('g');
   const dp = getByTestId('dp');
 
-  expect(a).toHaveAttribute('fill', '#000000ff');
-  expect(b).toHaveAttribute('fill', '#ff0000ff');
-  expect(c).toHaveAttribute('fill', '#000000ff');
-  expect(d).toHaveAttribute('fill', '#ff0000ff');
-  expect(e).toHaveAttribute('fill', '#000000ff');
-  expect(f).toHaveAttribute('fill', '#ff0000ff');
-  expect(g).toHaveAttribute('fill', '#000000ff');
-  expect(dp).toHaveAttribute('fill', '#ff0000ff');
+  expect(a).toHaveAttribute('fill', '#000000');
+  expect(b).toHaveAttribute('fill', '#ff0000');
+  expect(c).toHaveAttribute('fill', '#000000');
+  expect(d).toHaveAttribute('fill', '#ff0000');
+  expect(e).toHaveAttribute('fill', '#000000');
+  expect(f).toHaveAttribute('fill', '#ff0000');
+  expect(g).toHaveAttribute('fill', '#000000');
+  expect(dp).toHaveAttribute('fill', '#ff0000');
 });
 
 it('should turn on the correct display segments when configured with active on high', () => {
@@ -90,12 +90,12 @@ it('should turn on the correct display segments when configured with active on h
   const g = getByTestId('g');
   const dp = getByTestId('dp');
 
-  expect(a).toHaveAttribute('fill', '#ff0000ff');
-  expect(b).toHaveAttribute('fill', '#000000ff');
-  expect(c).toHaveAttribute('fill', '#ff0000ff');
-  expect(d).toHaveAttribute('fill', '#000000ff');
-  expect(e).toHaveAttribute('fill', '#ff0000ff');
-  expect(f).toHaveAttribute('fill', '#000000ff');
-  expect(g).toHaveAttribute('fill', '#ff0000ff');
-  expect(dp).toHaveAttribute('fill', '#000000ff');
+  expect(a).toHaveAttribute('fill', '#ff0000');
+  expect(b).toHaveAttribute('fill', '#000000');
+  expect(c).toHaveAttribute('fill', '#ff0000');
+  expect(d).toHaveAttribute('fill', '#000000');
+  expect(e).toHaveAttribute('fill', '#ff0000');
+  expect(f).toHaveAttribute('fill', '#000000');
+  expect(g).toHaveAttribute('fill', '#ff0000');
+  expect(dp).toHaveAttribute('fill', '#000000');
 });

--- a/packages/@logossim/components/Ssd/__tests__/SsdWidget.test.jsx
+++ b/packages/@logossim/components/Ssd/__tests__/SsdWidget.test.jsx
@@ -1,18 +1,13 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import SsdModel from '../SsdModel';
 import SsdWidget from '../SsdWidget';
-
-const { engine } = global;
 
 it('should have all input ports', () => {
   const model = new SsdModel();
 
-  const { container } = render(
-    <SsdWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<SsdWidget model={model} />);
 
   const portA = container.querySelector('[data-name=a]');
   const portB = container.querySelector('[data-name=b]');
@@ -48,9 +43,7 @@ it('should turn on the correct display segments when configured with active on h
     return [0];
   });
 
-  const { getByTestId } = render(
-    <SsdWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<SsdWidget model={model} />);
 
   const a = getByTestId('a');
   const b = getByTestId('b');
@@ -86,9 +79,7 @@ it('should turn on the correct display segments when configured with active on h
     return [0];
   });
 
-  const { getByTestId } = render(
-    <SsdWidget model={model} engine={engine} />,
-  );
+  const { getByTestId } = render(<SsdWidget model={model} />);
 
   const a = getByTestId('a');
   const b = getByTestId('b');

--- a/packages/@logossim/components/Ssd/__tests__/SsdWidget.test.jsx
+++ b/packages/@logossim/components/Ssd/__tests__/SsdWidget.test.jsx
@@ -4,98 +4,100 @@ import { render } from '../../testUtils';
 import SsdModel from '../SsdModel';
 import SsdWidget from '../SsdWidget';
 
-it('should have all input ports', () => {
-  const model = new SsdModel();
+describe('SsdWidget', () => {
+  it('should have all input ports', () => {
+    const model = new SsdModel();
 
-  const { container } = render(<SsdWidget model={model} />);
+    const { container } = render(<SsdWidget model={model} />);
 
-  const portA = container.querySelector('[data-name=a]');
-  const portB = container.querySelector('[data-name=b]');
-  const portC = container.querySelector('[data-name=c]');
-  const portD = container.querySelector('[data-name=d]');
-  const portE = container.querySelector('[data-name=e]');
-  const portF = container.querySelector('[data-name=f]');
-  const portG = container.querySelector('[data-name=g]');
-  const portDP = container.querySelector('[data-name=dp]');
+    const portA = container.querySelector('[data-name=a]');
+    const portB = container.querySelector('[data-name=b]');
+    const portC = container.querySelector('[data-name=c]');
+    const portD = container.querySelector('[data-name=d]');
+    const portE = container.querySelector('[data-name=e]');
+    const portF = container.querySelector('[data-name=f]');
+    const portG = container.querySelector('[data-name=g]');
+    const portDP = container.querySelector('[data-name=dp]');
 
-  expect(portA).toBeTruthy();
-  expect(portB).toBeTruthy();
-  expect(portC).toBeTruthy();
-  expect(portD).toBeTruthy();
-  expect(portE).toBeTruthy();
-  expect(portF).toBeTruthy();
-  expect(portG).toBeTruthy();
-  expect(portDP).toBeTruthy();
-});
-
-it('should turn on the correct display segments when configured with active on high', () => {
-  const model = new SsdModel({
-    ACTIVE_WHEN: 'LOW',
-    ON_COLOR: '#ff0000',
-    OFF_COLOR: '#000000',
-  });
-  const spy = jest.spyOn(model, 'getInput');
-  spy.mockImplementation(segment => {
-    if (segment === 'a') return [1];
-    if (segment === 'c') return [1];
-    if (segment === 'e') return [1];
-    if (segment === 'g') return [1];
-    return [0];
+    expect(portA).toBeTruthy();
+    expect(portB).toBeTruthy();
+    expect(portC).toBeTruthy();
+    expect(portD).toBeTruthy();
+    expect(portE).toBeTruthy();
+    expect(portF).toBeTruthy();
+    expect(portG).toBeTruthy();
+    expect(portDP).toBeTruthy();
   });
 
-  const { getByTestId } = render(<SsdWidget model={model} />);
+  it('should turn on the correct display segments when configured with active on high', () => {
+    const model = new SsdModel({
+      ACTIVE_WHEN: 'LOW',
+      ON_COLOR: '#ff0000',
+      OFF_COLOR: '#000000',
+    });
+    const spy = jest.spyOn(model, 'getInput');
+    spy.mockImplementation(segment => {
+      if (segment === 'a') return [1];
+      if (segment === 'c') return [1];
+      if (segment === 'e') return [1];
+      if (segment === 'g') return [1];
+      return [0];
+    });
 
-  const a = getByTestId('a');
-  const b = getByTestId('b');
-  const c = getByTestId('c');
-  const d = getByTestId('d');
-  const e = getByTestId('e');
-  const f = getByTestId('f');
-  const g = getByTestId('g');
-  const dp = getByTestId('dp');
+    const { getByTestId } = render(<SsdWidget model={model} />);
 
-  expect(a).toHaveAttribute('fill', '#000000');
-  expect(b).toHaveAttribute('fill', '#ff0000');
-  expect(c).toHaveAttribute('fill', '#000000');
-  expect(d).toHaveAttribute('fill', '#ff0000');
-  expect(e).toHaveAttribute('fill', '#000000');
-  expect(f).toHaveAttribute('fill', '#ff0000');
-  expect(g).toHaveAttribute('fill', '#000000');
-  expect(dp).toHaveAttribute('fill', '#ff0000');
-});
+    const a = getByTestId('a');
+    const b = getByTestId('b');
+    const c = getByTestId('c');
+    const d = getByTestId('d');
+    const e = getByTestId('e');
+    const f = getByTestId('f');
+    const g = getByTestId('g');
+    const dp = getByTestId('dp');
 
-it('should turn on the correct display segments when configured with active on high', () => {
-  const model = new SsdModel({
-    ACTIVE_WHEN: 'HIGH',
-    ON_COLOR: '#ff0000',
-    OFF_COLOR: '#000000',
+    expect(a).toHaveAttribute('fill', '#000000');
+    expect(b).toHaveAttribute('fill', '#ff0000');
+    expect(c).toHaveAttribute('fill', '#000000');
+    expect(d).toHaveAttribute('fill', '#ff0000');
+    expect(e).toHaveAttribute('fill', '#000000');
+    expect(f).toHaveAttribute('fill', '#ff0000');
+    expect(g).toHaveAttribute('fill', '#000000');
+    expect(dp).toHaveAttribute('fill', '#ff0000');
   });
-  const spy = jest.spyOn(model, 'getInput');
-  spy.mockImplementation(segment => {
-    if (segment === 'a') return [1];
-    if (segment === 'c') return [1];
-    if (segment === 'e') return [1];
-    if (segment === 'g') return [1];
-    return [0];
+
+  it('should turn on the correct display segments when configured with active on high', () => {
+    const model = new SsdModel({
+      ACTIVE_WHEN: 'HIGH',
+      ON_COLOR: '#ff0000',
+      OFF_COLOR: '#000000',
+    });
+    const spy = jest.spyOn(model, 'getInput');
+    spy.mockImplementation(segment => {
+      if (segment === 'a') return [1];
+      if (segment === 'c') return [1];
+      if (segment === 'e') return [1];
+      if (segment === 'g') return [1];
+      return [0];
+    });
+
+    const { getByTestId } = render(<SsdWidget model={model} />);
+
+    const a = getByTestId('a');
+    const b = getByTestId('b');
+    const c = getByTestId('c');
+    const d = getByTestId('d');
+    const e = getByTestId('e');
+    const f = getByTestId('f');
+    const g = getByTestId('g');
+    const dp = getByTestId('dp');
+
+    expect(a).toHaveAttribute('fill', '#ff0000');
+    expect(b).toHaveAttribute('fill', '#000000');
+    expect(c).toHaveAttribute('fill', '#ff0000');
+    expect(d).toHaveAttribute('fill', '#000000');
+    expect(e).toHaveAttribute('fill', '#ff0000');
+    expect(f).toHaveAttribute('fill', '#000000');
+    expect(g).toHaveAttribute('fill', '#ff0000');
+    expect(dp).toHaveAttribute('fill', '#000000');
   });
-
-  const { getByTestId } = render(<SsdWidget model={model} />);
-
-  const a = getByTestId('a');
-  const b = getByTestId('b');
-  const c = getByTestId('c');
-  const d = getByTestId('d');
-  const e = getByTestId('e');
-  const f = getByTestId('f');
-  const g = getByTestId('g');
-  const dp = getByTestId('dp');
-
-  expect(a).toHaveAttribute('fill', '#ff0000');
-  expect(b).toHaveAttribute('fill', '#000000');
-  expect(c).toHaveAttribute('fill', '#ff0000');
-  expect(d).toHaveAttribute('fill', '#000000');
-  expect(e).toHaveAttribute('fill', '#ff0000');
-  expect(f).toHaveAttribute('fill', '#000000');
-  expect(g).toHaveAttribute('fill', '#ff0000');
-  expect(dp).toHaveAttribute('fill', '#000000');
 });

--- a/packages/@logossim/components/Switch/SwitchWidget.jsx
+++ b/packages/@logossim/components/Switch/SwitchWidget.jsx
@@ -73,12 +73,7 @@ const SwitchWidget = props => {
       <Switch onClick={() => model.onClick()}>
         <SwitchValue isActive={model.isActive()} />
       </Switch>
-      <PositionedPort
-        name="out"
-        model={model}
-        port={model.getPort('out')}
-        engine={engine}
-      />
+      <PositionedPort name="out" model={model} engine={engine} />
     </Shape>
   );
 };

--- a/packages/@logossim/components/Switch/SwitchWidget.jsx
+++ b/packages/@logossim/components/Switch/SwitchWidget.jsx
@@ -63,7 +63,7 @@ export const SwitchValue = styled.div`
 `;
 
 const SwitchWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
   const {
     options: { selected },
   } = model;
@@ -73,7 +73,7 @@ const SwitchWidget = props => {
       <Switch onClick={() => model.onClick()}>
         <SwitchValue isActive={model.isActive()} />
       </Switch>
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} />
     </Shape>
   );
 };

--- a/packages/@logossim/components/Switch/SwitchWidget.jsx
+++ b/packages/@logossim/components/Switch/SwitchWidget.jsx
@@ -73,7 +73,7 @@ const SwitchWidget = props => {
       <Switch onClick={() => model.onClick()}>
         <SwitchValue isActive={model.isActive()} />
       </Switch>
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="out" />
     </Shape>
   );
 };

--- a/packages/@logossim/components/Switch/__tests__/SwitchModel.test.js
+++ b/packages/@logossim/components/Switch/__tests__/SwitchModel.test.js
@@ -2,41 +2,43 @@ import SwitchModel from '../SwitchModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const spy = jest.spyOn(SwitchModel.prototype, 'addOutputPort');
-  spy.mockImplementation(addPort);
+describe('SwitchModel', () => {
+  it('should add ports on initialization', () => {
+    const spy = jest.spyOn(SwitchModel.prototype, 'addOutputPort');
+    spy.mockImplementation(addPort);
 
-  new SwitchModel();
+    new SwitchModel();
 
-  expect(spy).toHaveBeenCalledWith('out');
-});
+    expect(spy).toHaveBeenCalledWith('out');
+  });
 
-it('should emit on simulation start', () => {
-  const model = new SwitchModel();
-  const spy = jest.spyOn(model, 'emit');
-  model.onSimulationStart();
+  it('should emit on simulation start', () => {
+    const model = new SwitchModel();
+    const spy = jest.spyOn(model, 'emit');
+    model.onSimulationStart();
 
-  expect(spy).toHaveBeenCalledWith({ out: 0 });
-});
+    expect(spy).toHaveBeenCalledWith({ out: 0 });
+  });
 
-it('should toggle to 1 upon clicking when value is 0', () => {
-  const model = new SwitchModel();
-  const emitSpy = jest.spyOn(model, 'emit');
-  const outputSpy = jest.spyOn(model, 'getOutput');
-  outputSpy.mockImplementation(() => 0);
+  it('should toggle to 1 upon clicking when value is 0', () => {
+    const model = new SwitchModel();
+    const emitSpy = jest.spyOn(model, 'emit');
+    const outputSpy = jest.spyOn(model, 'getOutput');
+    outputSpy.mockImplementation(() => 0);
 
-  model.onClick();
+    model.onClick();
 
-  expect(emitSpy).toHaveBeenCalledWith({ out: 1 });
-});
+    expect(emitSpy).toHaveBeenCalledWith({ out: 1 });
+  });
 
-it('should toggle to 0 upon clicking when value is 1', () => {
-  const model = new SwitchModel();
-  const emitSpy = jest.spyOn(model, 'emit');
-  const outputSpy = jest.spyOn(model, 'getOutput');
-  outputSpy.mockImplementation(() => 1);
+  it('should toggle to 0 upon clicking when value is 1', () => {
+    const model = new SwitchModel();
+    const emitSpy = jest.spyOn(model, 'emit');
+    const outputSpy = jest.spyOn(model, 'getOutput');
+    outputSpy.mockImplementation(() => 1);
 
-  model.onClick();
+    model.onClick();
 
-  expect(emitSpy).toHaveBeenCalledWith({ out: 0 });
+    expect(emitSpy).toHaveBeenCalledWith({ out: 0 });
+  });
 });

--- a/packages/@logossim/components/Switch/__tests__/SwitchModel.test.js
+++ b/packages/@logossim/components/Switch/__tests__/SwitchModel.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-new */
 import SwitchModel from '../SwitchModel';
 
 const { addPort } = global;

--- a/packages/@logossim/components/Switch/__tests__/SwitchWidget.test.jsx
+++ b/packages/@logossim/components/Switch/__tests__/SwitchWidget.test.jsx
@@ -1,18 +1,13 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import SwitchModel from '../SwitchModel';
 import SwitchWidget from '../SwitchWidget';
-
-const { engine } = global;
 
 it('should have 1 output port', () => {
   const model = new SwitchModel();
 
-  const { container } = render(
-    <SwitchWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<SwitchWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name=out]');
   expect(ports).toHaveLength(1);
@@ -22,9 +17,7 @@ it('should call model onClick on mouse down event', () => {
   const model = new SwitchModel();
   const spy = jest.spyOn(model, 'onClick');
 
-  const { getByRole } = render(
-    <SwitchWidget model={model} engine={engine} />,
-  );
+  const { getByRole } = render(<SwitchWidget model={model} />);
   const button = getByRole('button');
 
   button.click();
@@ -37,9 +30,7 @@ it('should translate value indicator to left when value is 0', () => {
   const spy = jest.spyOn(model, 'getOutput');
   spy.mockImplementation(() => [0]);
 
-  const { getByRole } = render(
-    <SwitchWidget model={model} engine={engine} />,
-  );
+  const { getByRole } = render(<SwitchWidget model={model} />);
   const button = getByRole('button');
   const value = button.children[0];
 
@@ -51,9 +42,7 @@ it('should translate value indicator to right when value is 1', () => {
   const spy = jest.spyOn(model, 'getOutput');
   spy.mockImplementation(() => [1]);
 
-  const { getByRole } = render(
-    <SwitchWidget model={model} engine={engine} />,
-  );
+  const { getByRole } = render(<SwitchWidget model={model} />);
   const button = getByRole('button');
   const value = button.children[0];
 

--- a/packages/@logossim/components/Switch/__tests__/SwitchWidget.test.jsx
+++ b/packages/@logossim/components/Switch/__tests__/SwitchWidget.test.jsx
@@ -4,47 +4,49 @@ import { render } from '../../testUtils';
 import SwitchModel from '../SwitchModel';
 import SwitchWidget from '../SwitchWidget';
 
-it('should have 1 output port', () => {
-  const model = new SwitchModel();
+describe('SwitchWidget', () => {
+  it('should have 1 output port', () => {
+    const model = new SwitchModel();
 
-  const { container } = render(<SwitchWidget model={model} />);
+    const { container } = render(<SwitchWidget model={model} />);
 
-  const ports = container.querySelectorAll('[data-name=out]');
-  expect(ports).toHaveLength(1);
-});
+    const ports = container.querySelectorAll('[data-name=out]');
+    expect(ports).toHaveLength(1);
+  });
 
-it('should call model onClick on mouse down event', () => {
-  const model = new SwitchModel();
-  const spy = jest.spyOn(model, 'onClick');
+  it('should call model onClick on mouse down event', () => {
+    const model = new SwitchModel();
+    const spy = jest.spyOn(model, 'onClick');
 
-  const { getByRole } = render(<SwitchWidget model={model} />);
-  const button = getByRole('button');
+    const { getByRole } = render(<SwitchWidget model={model} />);
+    const button = getByRole('button');
 
-  button.click();
+    button.click();
 
-  expect(spy).toHaveBeenCalledTimes(1);
-});
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
 
-it('should translate value indicator to left when value is 0', () => {
-  const model = new SwitchModel();
-  const spy = jest.spyOn(model, 'getOutput');
-  spy.mockImplementation(() => [0]);
+  it('should translate value indicator to left when value is 0', () => {
+    const model = new SwitchModel();
+    const spy = jest.spyOn(model, 'getOutput');
+    spy.mockImplementation(() => [0]);
 
-  const { getByRole } = render(<SwitchWidget model={model} />);
-  const button = getByRole('button');
-  const value = button.children[0];
+    const { getByRole } = render(<SwitchWidget model={model} />);
+    const button = getByRole('button');
+    const value = button.children[0];
 
-  expect(value).toHaveStyle('transform: translateX(-6px)');
-});
+    expect(value).toHaveStyle('transform: translateX(-6px)');
+  });
 
-it('should translate value indicator to right when value is 1', () => {
-  const model = new SwitchModel();
-  const spy = jest.spyOn(model, 'getOutput');
-  spy.mockImplementation(() => [1]);
+  it('should translate value indicator to right when value is 1', () => {
+    const model = new SwitchModel();
+    const spy = jest.spyOn(model, 'getOutput');
+    spy.mockImplementation(() => [1]);
 
-  const { getByRole } = render(<SwitchWidget model={model} />);
-  const button = getByRole('button');
-  const value = button.children[0];
+    const { getByRole } = render(<SwitchWidget model={model} />);
+    const button = getByRole('button');
+    const value = button.children[0];
 
-  expect(value).toHaveStyle('transform: translateX(6px)');
+    expect(value).toHaveStyle('transform: translateX(6px)');
+  });
 });

--- a/packages/@logossim/components/Xnor/XnorModel.js
+++ b/packages/@logossim/components/Xnor/XnorModel.js
@@ -3,53 +3,42 @@ import { BaseModel } from '@logossim/core';
 export default class XnorModel extends BaseModel {
   initialize(configurations) {
     this.behavior = configurations.MULTIPLE_INPUT_BEHAVIOR;
-    this.bits = Number(configurations.DATA_BITS);
+    this.dataBits = Number(configurations.DATA_BITS);
 
     const INPUT_PORTS_NUMBER = Number(
       configurations.INPUT_PORTS_NUMBER,
     );
 
     for (let i = 0; i < INPUT_PORTS_NUMBER; i += 1) {
-      this.addInputPort(`in${i}`, { bits: this.bits });
+      this.addInputPort(`in${i}`, { bits: this.dataBits });
     }
-    this.addOutputPort('out', { bits: this.bits });
+    this.addOutputPort('out', { bits: this.dataBits });
   }
 
-  notExclusiveOrAt(values, index) {
-    const mask = 0b1 << index;
+  executeBit(bits) {
+    if (this.behavior === 'ONE') return this.executeOne(bits);
+    if (this.behavior === 'ODD') return this.executeOdd(bits);
+    return {};
+  }
 
-    const sum = values
-      .map(value => ((value & mask) > 0 ? 1 : 0))
-      .reduce((acc, curr) => acc + curr);
+  executeOne(bits) {
+    return bits.filter(bit => bit === 1).length === 1 ? 0 : 1;
+  }
 
-    return sum === 1 ? 0 : 1;
+  executeOdd(bits) {
+    return bits.filter(bit => bit === 1).length % 2 ? 0 : 1;
   }
 
   step(input) {
-    const MAX_VALUE = 0b1111_1111_1111_1111_1111_1111_1111_1111;
-    const mask = MAX_VALUE >>> (32 - this.bits);
+    return {
+      out: Object.values(input)
+        .map(value => value.asArray(this.dataBits))
+        .transpose()
+        .map(this.executeBit.bind(this)),
+    };
+  }
 
-    const values = Object.values(input);
-
-    switch (this.behavior) {
-      case 'ONE':
-        return {
-          out: parseInt(
-            [...new Array(this.bits)]
-              .map((_, index) => this.notExclusiveOrAt(values, index))
-              .reverse()
-              .join(''),
-            2,
-          ),
-        };
-      case 'ODD': {
-        const xor = values.reduce((acc, curr) => curr ^ acc);
-        return {
-          out: ~xor & mask,
-        };
-      }
-      default:
-        return {};
-    }
+  stepFloating(input) {
+    return this.step(input);
   }
 }

--- a/packages/@logossim/components/Xnor/XnorModel.js
+++ b/packages/@logossim/components/Xnor/XnorModel.js
@@ -10,9 +10,9 @@ export default class XnorModel extends BaseModel {
     );
 
     for (let i = 0; i < INPUT_PORTS_NUMBER; i += 1) {
-      this.addInputPort(`in${i}`, this.bits);
+      this.addInputPort(`in${i}`, { bits: this.bits });
     }
-    this.addOutputPort('out', this.bits);
+    this.addOutputPort('out', { bits: this.bits });
   }
 
   notExclusiveOrAt(values, index) {

--- a/packages/@logossim/components/Xnor/XnorWidget.jsx
+++ b/packages/@logossim/components/Xnor/XnorWidget.jsx
@@ -121,7 +121,6 @@ const XnorWidget = props => {
         <Fragment key={port.getName()}>
           <PositionedPort
             name={port.getName()}
-            model={model}
             position={portPositions[i]}
           />
           {(portPositions[i] < 1 || portPositions[i] > 5) && (
@@ -132,7 +131,7 @@ const XnorWidget = props => {
           )}
         </Fragment>
       ))}
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="out" />
       <Shape portPositions={portPositions} />
     </Wrapper>
   );

--- a/packages/@logossim/components/Xnor/XnorWidget.jsx
+++ b/packages/@logossim/components/Xnor/XnorWidget.jsx
@@ -105,7 +105,7 @@ export const Shape = ({ size = 90, portPositions = [] }) => (
 );
 
 const XnorWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
 
   const inputPorts = Object.values(model.getInputPorts());
   const portPositions = distributePorts(inputPorts.length);
@@ -122,7 +122,6 @@ const XnorWidget = props => {
           <PositionedPort
             name={port.getName()}
             model={model}
-            engine={engine}
             position={portPositions[i]}
           />
           {(portPositions[i] < 1 || portPositions[i] > 5) && (
@@ -133,7 +132,7 @@ const XnorWidget = props => {
           )}
         </Fragment>
       ))}
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} />
       <Shape portPositions={portPositions} />
     </Wrapper>
   );

--- a/packages/@logossim/components/Xnor/XnorWidget.jsx
+++ b/packages/@logossim/components/Xnor/XnorWidget.jsx
@@ -122,7 +122,6 @@ const XnorWidget = props => {
           <PositionedPort
             name={port.getName()}
             model={model}
-            port={port}
             engine={engine}
             position={portPositions[i]}
           />
@@ -134,12 +133,7 @@ const XnorWidget = props => {
           )}
         </Fragment>
       ))}
-      <PositionedPort
-        name="out"
-        model={model}
-        port={model.getPort('out')}
-        engine={engine}
-      />
+      <PositionedPort name="out" model={model} engine={engine} />
       <Shape portPositions={portPositions} />
     </Wrapper>
   );

--- a/packages/@logossim/components/Xnor/__tests__/XnorModel.test.js
+++ b/packages/@logossim/components/Xnor/__tests__/XnorModel.test.js
@@ -2,348 +2,353 @@ import XnorModel from '../XnorModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const addInputSpy = jest.spyOn(XnorModel.prototype, 'addInputPort');
-  addInputSpy.mockImplementation(addPort);
+describe('XnorModel', () => {
+  it('should add ports on initialization', () => {
+    const addInputSpy = jest.spyOn(
+      XnorModel.prototype,
+      'addInputPort',
+    );
+    addInputSpy.mockImplementation(addPort);
 
-  const addOutputSpy = jest.spyOn(
-    XnorModel.prototype,
-    'addOutputPort',
-  );
-  addOutputSpy.mockImplementation(addPort);
+    const addOutputSpy = jest.spyOn(
+      XnorModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  new XnorModel({
-    INPUT_PORTS_NUMBER: 16,
-    DATA_BITS: 1,
-  });
-
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
-  [...Array(16).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
-      bits: 1,
-    });
-  });
-});
-
-describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
-  it("should return 0 when there's only 1 high input", () => {
-    const model = new XnorModel({
-      MULTIPLE_INPUT_BEHAVIOR: 'ONE',
-      INPUT_PORTS_NUMBER: 4,
+    new XnorModel({
+      INPUT_PORTS_NUMBER: 16,
       DATA_BITS: 1,
     });
 
-    expect(
-      model.step({
-        in0: 1,
-        in1: 0,
-        in2: 0,
-        in3: 0,
-      }),
-    ).toEqual({ out: [0] });
-
-    expect(
-      model.step({
-        in0: 0,
-        in1: 1,
-        in2: 0,
-        in3: 0,
-      }),
-    ).toEqual({ out: [0] });
-
-    expect(
-      model.step({
-        in0: 0,
-        in1: 0,
-        in2: 1,
-        in3: 0,
-      }),
-    ).toEqual({ out: [0] });
-
-    expect(
-      model.step({
-        in0: 0,
-        in1: 0,
-        in2: 0,
-        in3: 1,
-      }),
-    ).toEqual({ out: [0] });
-
-    expect(
-      model.stepFloating({
-        in0: ['x'],
-        in1: [0],
-        in2: [0],
-        in3: [1],
-      }),
-    ).toEqual({ out: [0] });
-  });
-
-  it("should return 1 when there's more than 1 high input", () => {
-    const model = new XnorModel({
-      MULTIPLE_INPUT_BEHAVIOR: 'ONE',
-      INPUT_PORTS_NUMBER: 4,
-      DATA_BITS: 1,
-    });
-
-    expect(
-      model.step({
-        in0: 1,
-        in1: 1,
-        in2: 0,
-        in3: 0,
-      }),
-    ).toEqual({ out: [1] });
-
-    expect(
-      model.step({
-        in0: 0,
-        in1: 1,
-        in2: 1,
-        in3: 0,
-      }),
-    ).toEqual({ out: [1] });
-
-    expect(
-      model.step({
-        in0: 0,
-        in1: 0,
-        in2: 1,
-        in3: 1,
-      }),
-    ).toEqual({ out: [1] });
-
-    expect(
-      model.step({
-        in0: 1,
-        in1: 0,
-        in2: 0,
-        in3: 1,
-      }),
-    ).toEqual({ out: [1] });
-
-    expect(
-      model.step({
-        in0: 1,
-        in1: 1,
-        in2: 1,
-        in3: 0,
-      }),
-    ).toEqual({ out: [1] });
-
-    expect(
-      model.step({
-        in0: 1,
-        in1: 1,
-        in2: 1,
-        in3: 1,
-      }),
-    ).toEqual({ out: [1] });
-
-    expect(
-      model.stepFloating({
-        in0: [1],
-        in1: [1],
-        in2: [1],
-        in3: ['x'],
-      }),
-    ).toEqual({ out: [1] });
-  });
-
-  it('should return 1 when all inputs are 0', () => {
-    const model = new XnorModel({
-      MULTIPLE_INPUT_BEHAVIOR: 'ONE',
-      INPUT_PORTS_NUMBER: 4,
-      DATA_BITS: 1,
-    });
-
-    expect(
-      model.step({
-        in0: 0,
-        in1: 0,
-        in2: 0,
-        in3: 0,
-      }),
-    ).toEqual({ out: [1] });
-  });
-
-  it('should return bitwise XNOR for multiple data bits', () => {
-    const DATA_BITS = 8;
-
-    const model = new XnorModel({
-      MULTIPLE_INPUT_BEHAVIOR: 'ONE',
-      INPUT_PORTS_NUMBER: 5,
-      DATA_BITS,
-    });
-
-    expect(
-      model.step({
-        in0: 0b0110_1000,
-        in1: 0b0100_0100,
-        in2: 0b0111_0010,
-        in3: 0b0101_0001,
-      }),
-    ).toEqual({
-      out: (0b1111_0000).asArray(DATA_BITS),
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
+    [...Array(16).keys()].forEach(i => {
+      expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
+        bits: 1,
+      });
     });
   });
-});
 
-describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
-  it("should return 0 when there's an odd number of high inputs", () => {
-    const model = new XnorModel({
-      MULTIPLE_INPUT_BEHAVIOR: 'ODD',
-      INPUT_PORTS_NUMBER: 5,
-      DATA_BITS: 1,
+  describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
+    it("should return 0 when there's only 1 high input", () => {
+      const model = new XnorModel({
+        MULTIPLE_INPUT_BEHAVIOR: 'ONE',
+        INPUT_PORTS_NUMBER: 4,
+        DATA_BITS: 1,
+      });
+
+      expect(
+        model.step({
+          in0: 1,
+          in1: 0,
+          in2: 0,
+          in3: 0,
+        }),
+      ).toEqual({ out: [0] });
+
+      expect(
+        model.step({
+          in0: 0,
+          in1: 1,
+          in2: 0,
+          in3: 0,
+        }),
+      ).toEqual({ out: [0] });
+
+      expect(
+        model.step({
+          in0: 0,
+          in1: 0,
+          in2: 1,
+          in3: 0,
+        }),
+      ).toEqual({ out: [0] });
+
+      expect(
+        model.step({
+          in0: 0,
+          in1: 0,
+          in2: 0,
+          in3: 1,
+        }),
+      ).toEqual({ out: [0] });
+
+      expect(
+        model.stepFloating({
+          in0: ['x'],
+          in1: [0],
+          in2: [0],
+          in3: [1],
+        }),
+      ).toEqual({ out: [0] });
     });
 
-    expect(
-      model.step({
-        in0: 1,
-        in1: 0,
-        in2: 0,
-        in3: 0,
-        in4: 0,
-      }),
-    ).toEqual({ out: [0] });
+    it("should return 1 when there's more than 1 high input", () => {
+      const model = new XnorModel({
+        MULTIPLE_INPUT_BEHAVIOR: 'ONE',
+        INPUT_PORTS_NUMBER: 4,
+        DATA_BITS: 1,
+      });
 
-    expect(
-      model.step({
-        in0: 1,
-        in1: 1,
-        in2: 1,
-        in3: 0,
-        in4: 0,
-      }),
-    ).toEqual({ out: [0] });
+      expect(
+        model.step({
+          in0: 1,
+          in1: 1,
+          in2: 0,
+          in3: 0,
+        }),
+      ).toEqual({ out: [1] });
 
-    expect(
-      model.step({
-        in0: 1,
-        in1: 1,
-        in2: 1,
-        in3: 1,
-        in4: 1,
-      }),
-    ).toEqual({ out: [0] });
+      expect(
+        model.step({
+          in0: 0,
+          in1: 1,
+          in2: 1,
+          in3: 0,
+        }),
+      ).toEqual({ out: [1] });
 
-    expect(
-      model.stepFloating({
-        in0: [0],
-        in1: [1],
-        in2: ['x'],
-        in3: [0],
-      }),
-    ).toEqual({ out: [0] });
+      expect(
+        model.step({
+          in0: 0,
+          in1: 0,
+          in2: 1,
+          in3: 1,
+        }),
+      ).toEqual({ out: [1] });
 
-    expect(
-      model.stepFloating({
-        in0: [1],
-        in1: [1],
-        in2: ['x'],
-        in3: [1],
-      }),
-    ).toEqual({ out: [0] });
+      expect(
+        model.step({
+          in0: 1,
+          in1: 0,
+          in2: 0,
+          in3: 1,
+        }),
+      ).toEqual({ out: [1] });
+
+      expect(
+        model.step({
+          in0: 1,
+          in1: 1,
+          in2: 1,
+          in3: 0,
+        }),
+      ).toEqual({ out: [1] });
+
+      expect(
+        model.step({
+          in0: 1,
+          in1: 1,
+          in2: 1,
+          in3: 1,
+        }),
+      ).toEqual({ out: [1] });
+
+      expect(
+        model.stepFloating({
+          in0: [1],
+          in1: [1],
+          in2: [1],
+          in3: ['x'],
+        }),
+      ).toEqual({ out: [1] });
+    });
+
+    it('should return 1 when all inputs are 0', () => {
+      const model = new XnorModel({
+        MULTIPLE_INPUT_BEHAVIOR: 'ONE',
+        INPUT_PORTS_NUMBER: 4,
+        DATA_BITS: 1,
+      });
+
+      expect(
+        model.step({
+          in0: 0,
+          in1: 0,
+          in2: 0,
+          in3: 0,
+        }),
+      ).toEqual({ out: [1] });
+    });
+
+    it('should return bitwise XNOR for multiple data bits', () => {
+      const DATA_BITS = 8;
+
+      const model = new XnorModel({
+        MULTIPLE_INPUT_BEHAVIOR: 'ONE',
+        INPUT_PORTS_NUMBER: 5,
+        DATA_BITS,
+      });
+
+      expect(
+        model.step({
+          in0: 0b0110_1000,
+          in1: 0b0100_0100,
+          in2: 0b0111_0010,
+          in3: 0b0101_0001,
+        }),
+      ).toEqual({
+        out: (0b1111_0000).asArray(DATA_BITS),
+      });
+    });
   });
 
-  it("should return 0 when there's an odd number of high inputs", () => {
-    const model = new XnorModel({
-      MULTIPLE_INPUT_BEHAVIOR: 'ODD',
-      INPUT_PORTS_NUMBER: 4,
-      DATA_BITS: 1,
+  describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
+    it("should return 0 when there's an odd number of high inputs", () => {
+      const model = new XnorModel({
+        MULTIPLE_INPUT_BEHAVIOR: 'ODD',
+        INPUT_PORTS_NUMBER: 5,
+        DATA_BITS: 1,
+      });
+
+      expect(
+        model.step({
+          in0: 1,
+          in1: 0,
+          in2: 0,
+          in3: 0,
+          in4: 0,
+        }),
+      ).toEqual({ out: [0] });
+
+      expect(
+        model.step({
+          in0: 1,
+          in1: 1,
+          in2: 1,
+          in3: 0,
+          in4: 0,
+        }),
+      ).toEqual({ out: [0] });
+
+      expect(
+        model.step({
+          in0: 1,
+          in1: 1,
+          in2: 1,
+          in3: 1,
+          in4: 1,
+        }),
+      ).toEqual({ out: [0] });
+
+      expect(
+        model.stepFloating({
+          in0: [0],
+          in1: [1],
+          in2: ['x'],
+          in3: [0],
+        }),
+      ).toEqual({ out: [0] });
+
+      expect(
+        model.stepFloating({
+          in0: [1],
+          in1: [1],
+          in2: ['x'],
+          in3: [1],
+        }),
+      ).toEqual({ out: [0] });
     });
 
-    expect(
-      model.step({
-        in0: 0,
-        in1: 0,
-        in2: 0,
-        in3: 0,
-      }),
-    ).toEqual({ out: [1] });
+    it("should return 0 when there's an odd number of high inputs", () => {
+      const model = new XnorModel({
+        MULTIPLE_INPUT_BEHAVIOR: 'ODD',
+        INPUT_PORTS_NUMBER: 4,
+        DATA_BITS: 1,
+      });
 
-    expect(
-      model.step({
-        in0: 1,
-        in1: 1,
-        in2: 0,
-        in3: 0,
-      }),
-    ).toEqual({ out: [1] });
+      expect(
+        model.step({
+          in0: 0,
+          in1: 0,
+          in2: 0,
+          in3: 0,
+        }),
+      ).toEqual({ out: [1] });
 
-    expect(
-      model.step({
-        in0: 0,
-        in1: 1,
-        in2: 1,
-        in3: 0,
-      }),
-    ).toEqual({ out: [1] });
+      expect(
+        model.step({
+          in0: 1,
+          in1: 1,
+          in2: 0,
+          in3: 0,
+        }),
+      ).toEqual({ out: [1] });
 
-    expect(
-      model.step({
-        in0: 0,
-        in1: 0,
-        in2: 1,
-        in3: 1,
-      }),
-    ).toEqual({ out: [1] });
+      expect(
+        model.step({
+          in0: 0,
+          in1: 1,
+          in2: 1,
+          in3: 0,
+        }),
+      ).toEqual({ out: [1] });
 
-    expect(
-      model.step({
-        in0: 1,
-        in1: 0,
-        in2: 0,
-        in3: 1,
-      }),
-    ).toEqual({ out: [1] });
+      expect(
+        model.step({
+          in0: 0,
+          in1: 0,
+          in2: 1,
+          in3: 1,
+        }),
+      ).toEqual({ out: [1] });
 
-    expect(
-      model.step({
-        in0: 1,
-        in1: 1,
-        in2: 1,
-        in3: 1,
-      }),
-    ).toEqual({ out: [1] });
+      expect(
+        model.step({
+          in0: 1,
+          in1: 0,
+          in2: 0,
+          in3: 1,
+        }),
+      ).toEqual({ out: [1] });
 
-    expect(
-      model.stepFloating({
-        in0: [0],
-        in1: [0],
-        in2: ['x'],
-        in3: [0],
-      }),
-    ).toEqual({ out: [1] });
+      expect(
+        model.step({
+          in0: 1,
+          in1: 1,
+          in2: 1,
+          in3: 1,
+        }),
+      ).toEqual({ out: [1] });
 
-    expect(
-      model.stepFloating({
-        in0: [0],
-        in1: [1],
-        in2: ['x'],
-        in3: [1],
-      }),
-    ).toEqual({ out: [1] });
-  });
+      expect(
+        model.stepFloating({
+          in0: [0],
+          in1: [0],
+          in2: ['x'],
+          in3: [0],
+        }),
+      ).toEqual({ out: [1] });
 
-  it('should return bitwise XOR for multiple data bits', () => {
-    const DATA_BITS = 8;
-
-    const model = new XnorModel({
-      MULTIPLE_INPUT_BEHAVIOR: 'ODD',
-      INPUT_PORTS_NUMBER: 5,
-      DATA_BITS,
+      expect(
+        model.stepFloating({
+          in0: [0],
+          in1: [1],
+          in2: ['x'],
+          in3: [1],
+        }),
+      ).toEqual({ out: [1] });
     });
 
-    expect(
-      model.step({
-        in0: 0b0000_0000,
-        in1: 0b0111_1000,
-        in2: 0b0110_0110,
-        in3: 0b0101_0101,
-      }),
-    ).toEqual({
-      out: (0b1011_0100).asArray(DATA_BITS),
+    it('should return bitwise XOR for multiple data bits', () => {
+      const DATA_BITS = 8;
+
+      const model = new XnorModel({
+        MULTIPLE_INPUT_BEHAVIOR: 'ODD',
+        INPUT_PORTS_NUMBER: 5,
+        DATA_BITS,
+      });
+
+      expect(
+        model.step({
+          in0: 0b0000_0000,
+          in1: 0b0111_1000,
+          in2: 0b0110_0110,
+          in3: 0b0101_0101,
+        }),
+      ).toEqual({
+        out: (0b1011_0100).asArray(DATA_BITS),
+      });
     });
   });
 });

--- a/packages/@logossim/components/Xnor/__tests__/XnorModel.test.js
+++ b/packages/@logossim/components/Xnor/__tests__/XnorModel.test.js
@@ -20,9 +20,11 @@ it('should add ports on initialization', () => {
     DATA_BITS: 1,
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', 1);
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
   [...Array(16).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, 1);
+    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
+      bits: 1,
+    });
   });
 });
 

--- a/packages/@logossim/components/Xnor/__tests__/XnorModel.test.js
+++ b/packages/@logossim/components/Xnor/__tests__/XnorModel.test.js
@@ -34,7 +34,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 0,
         in2: 0,
@@ -43,7 +43,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     ).toEqual({ out: [0] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 1,
         in2: 0,
@@ -52,7 +52,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     ).toEqual({ out: [0] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 0,
         in2: 1,
@@ -61,11 +61,20 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     ).toEqual({ out: [0] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 0,
         in2: 0,
         in3: 1,
+      }),
+    ).toEqual({ out: [0] });
+
+    expect(
+      model.stepFloating({
+        in0: ['x'],
+        in1: [0],
+        in2: [0],
+        in3: [1],
       }),
     ).toEqual({ out: [0] });
   });
@@ -78,7 +87,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 1,
         in2: 0,
@@ -87,7 +96,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     ).toEqual({ out: [1] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 1,
         in2: 1,
@@ -96,7 +105,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     ).toEqual({ out: [1] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 0,
         in2: 1,
@@ -105,7 +114,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     ).toEqual({ out: [1] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 0,
         in2: 0,
@@ -114,7 +123,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     ).toEqual({ out: [1] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 1,
         in2: 1,
@@ -123,11 +132,20 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     ).toEqual({ out: [1] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 1,
         in2: 1,
         in3: 1,
+      }),
+    ).toEqual({ out: [1] });
+
+    expect(
+      model.stepFloating({
+        in0: [1],
+        in1: [1],
+        in2: [1],
+        in3: ['x'],
       }),
     ).toEqual({ out: [1] });
   });
@@ -140,7 +158,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 0,
         in2: 0,
@@ -159,7 +177,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0b0110_1000,
         in1: 0b0100_0100,
         in2: 0b0111_0010,
@@ -172,7 +190,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
 });
 
 describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
-  it("should return 1 when there's an odd number of high inputs", () => {
+  it("should return 0 when there's an odd number of high inputs", () => {
     const model = new XnorModel({
       MULTIPLE_INPUT_BEHAVIOR: 'ODD',
       INPUT_PORTS_NUMBER: 5,
@@ -180,7 +198,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 0,
         in2: 0,
@@ -190,7 +208,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     ).toEqual({ out: [0] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 1,
         in2: 1,
@@ -200,12 +218,30 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     ).toEqual({ out: [0] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 1,
         in2: 1,
         in3: 1,
         in4: 1,
+      }),
+    ).toEqual({ out: [0] });
+
+    expect(
+      model.stepFloating({
+        in0: [0],
+        in1: [1],
+        in2: ['x'],
+        in3: [0],
+      }),
+    ).toEqual({ out: [0] });
+
+    expect(
+      model.stepFloating({
+        in0: [1],
+        in1: [1],
+        in2: ['x'],
+        in3: [1],
       }),
     ).toEqual({ out: [0] });
   });
@@ -218,7 +254,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 0,
         in2: 0,
@@ -227,7 +263,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     ).toEqual({ out: [1] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 1,
         in2: 0,
@@ -236,7 +272,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     ).toEqual({ out: [1] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 1,
         in2: 1,
@@ -245,7 +281,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     ).toEqual({ out: [1] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 0,
         in2: 1,
@@ -254,7 +290,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     ).toEqual({ out: [1] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 0,
         in2: 0,
@@ -263,11 +299,29 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     ).toEqual({ out: [1] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 1,
         in2: 1,
         in3: 1,
+      }),
+    ).toEqual({ out: [1] });
+
+    expect(
+      model.stepFloating({
+        in0: [0],
+        in1: [0],
+        in2: ['x'],
+        in3: [0],
+      }),
+    ).toEqual({ out: [1] });
+
+    expect(
+      model.stepFloating({
+        in0: [0],
+        in1: [1],
+        in2: ['x'],
+        in3: [1],
       }),
     ).toEqual({ out: [1] });
   });
@@ -282,7 +336,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0b0000_0000,
         in1: 0b0111_1000,
         in2: 0b0110_0110,

--- a/packages/@logossim/components/Xnor/__tests__/XnorModel.test.js
+++ b/packages/@logossim/components/Xnor/__tests__/XnorModel.test.js
@@ -1,6 +1,3 @@
-/* eslint-disable no-new */
-import { convertNumberValueToArray } from '@logossim/core/Simulation/utils';
-
 import XnorModel from '../XnorModel';
 
 const { addPort } = global;
@@ -169,7 +166,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
         in3: 0b0101_0001,
       }),
     ).toEqual({
-      out: convertNumberValueToArray(0b1111_0000, DATA_BITS),
+      out: (0b1111_0000).asArray(DATA_BITS),
     });
   });
 });
@@ -292,7 +289,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
         in3: 0b0101_0101,
       }),
     ).toEqual({
-      out: convertNumberValueToArray(0b1011_0100, DATA_BITS),
+      out: (0b1011_0100).asArray(DATA_BITS),
     });
   });
 });

--- a/packages/@logossim/components/Xnor/__tests__/XnorWidget.test.jsx
+++ b/packages/@logossim/components/Xnor/__tests__/XnorWidget.test.jsx
@@ -1,20 +1,15 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-
+import { render } from '../../testUtils';
 import XnorModel from '../XnorModel';
 import XnorWidget from '../XnorWidget';
-
-const { engine } = global;
 
 it('should have 1 output port', () => {
   const model = new XnorModel({
     DATA_BITS: 1,
   });
 
-  const { container } = render(
-    <XnorWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<XnorWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name=out]');
   expect(ports).toHaveLength(1);
@@ -26,9 +21,7 @@ it('should have the amount of input ports determined by configuration', () => {
     DATA_BITS: 1,
   });
 
-  const { container } = render(
-    <XnorWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<XnorWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name^=in]');
   expect(ports).toHaveLength(16);

--- a/packages/@logossim/components/Xnor/__tests__/XnorWidget.test.jsx
+++ b/packages/@logossim/components/Xnor/__tests__/XnorWidget.test.jsx
@@ -4,25 +4,27 @@ import { render } from '../../testUtils';
 import XnorModel from '../XnorModel';
 import XnorWidget from '../XnorWidget';
 
-it('should have 1 output port', () => {
-  const model = new XnorModel({
-    DATA_BITS: 1,
+describe('XnorWidget', () => {
+  it('should have 1 output port', () => {
+    const model = new XnorModel({
+      DATA_BITS: 1,
+    });
+
+    const { container } = render(<XnorWidget model={model} />);
+
+    const ports = container.querySelectorAll('[data-name=out]');
+    expect(ports).toHaveLength(1);
   });
 
-  const { container } = render(<XnorWidget model={model} />);
+  it('should have the amount of input ports determined by configuration', () => {
+    const model = new XnorModel({
+      INPUT_PORTS_NUMBER: 16,
+      DATA_BITS: 1,
+    });
 
-  const ports = container.querySelectorAll('[data-name=out]');
-  expect(ports).toHaveLength(1);
-});
+    const { container } = render(<XnorWidget model={model} />);
 
-it('should have the amount of input ports determined by configuration', () => {
-  const model = new XnorModel({
-    INPUT_PORTS_NUMBER: 16,
-    DATA_BITS: 1,
+    const ports = container.querySelectorAll('[data-name^=in]');
+    expect(ports).toHaveLength(16);
   });
-
-  const { container } = render(<XnorWidget model={model} />);
-
-  const ports = container.querySelectorAll('[data-name^=in]');
-  expect(ports).toHaveLength(16);
 });

--- a/packages/@logossim/components/Xor/XorModel.js
+++ b/packages/@logossim/components/Xor/XorModel.js
@@ -3,48 +3,42 @@ import { BaseModel } from '@logossim/core';
 export default class XorModel extends BaseModel {
   initialize(configurations) {
     this.behavior = configurations.MULTIPLE_INPUT_BEHAVIOR;
-    this.bits = Number(configurations.DATA_BITS);
+    this.dataBits = Number(configurations.DATA_BITS);
 
     const INPUT_PORTS_NUMBER = Number(
       configurations.INPUT_PORTS_NUMBER,
     );
 
     for (let i = 0; i < INPUT_PORTS_NUMBER; i += 1) {
-      this.addInputPort(`in${i}`, { bits: this.bits });
+      this.addInputPort(`in${i}`, { bits: this.dataBits });
     }
-    this.addOutputPort('out', { bits: this.bits });
+    this.addOutputPort('out', { bits: this.dataBits });
   }
 
-  exclusiveOrAt(values, index) {
-    const mask = 0b1 << index;
+  executeBit(bits) {
+    if (this.behavior === 'ONE') return this.executeOne(bits);
+    if (this.behavior === 'ODD') return this.executeOdd(bits);
+    return {};
+  }
 
-    const sum = values
-      .map(value => ((value & mask) > 0 ? 1 : 0))
-      .reduce((acc, curr) => acc + curr);
+  executeOne(bits) {
+    return bits.filter(bit => bit === 1).length === 1 ? 1 : 0;
+  }
 
-    return sum === 1 ? 1 : 0;
+  executeOdd(bits) {
+    return bits.filter(bit => bit === 1).length % 2 ? 1 : 0;
   }
 
   step(input) {
-    const values = Object.values(input);
+    return {
+      out: Object.values(input)
+        .map(value => value.asArray(this.dataBits))
+        .transpose()
+        .map(this.executeBit.bind(this)),
+    };
+  }
 
-    switch (this.behavior) {
-      case 'ONE':
-        return {
-          out: parseInt(
-            [...new Array(this.bits)]
-              .map((_, index) => this.exclusiveOrAt(values, index))
-              .reverse()
-              .join(''),
-            2,
-          ),
-        };
-      case 'ODD':
-        return {
-          out: values.reduce((acc, curr) => curr ^ acc),
-        };
-      default:
-        return {};
-    }
+  stepFloating(input) {
+    return this.step(input);
   }
 }

--- a/packages/@logossim/components/Xor/XorModel.js
+++ b/packages/@logossim/components/Xor/XorModel.js
@@ -10,9 +10,9 @@ export default class XorModel extends BaseModel {
     );
 
     for (let i = 0; i < INPUT_PORTS_NUMBER; i += 1) {
-      this.addInputPort(`in${i}`, this.bits);
+      this.addInputPort(`in${i}`, { bits: this.bits });
     }
-    this.addOutputPort('out', this.bits);
+    this.addOutputPort('out', { bits: this.bits });
   }
 
   exclusiveOrAt(values, index) {

--- a/packages/@logossim/components/Xor/XorWidget.jsx
+++ b/packages/@logossim/components/Xor/XorWidget.jsx
@@ -120,7 +120,6 @@ const XorWidget = props => {
         <Fragment key={port.getName()}>
           <PositionedPort
             name={port.getName()}
-            model={model}
             position={portPositions[i]}
           />
           {(portPositions[i] < 1 || portPositions[i] > 5) && (
@@ -131,7 +130,7 @@ const XorWidget = props => {
           )}
         </Fragment>
       ))}
-      <PositionedPort name="out" model={model} />
+      <PositionedPort name="out" />
       <Shape portPositions={portPositions} />
     </Wrapper>
   );

--- a/packages/@logossim/components/Xor/XorWidget.jsx
+++ b/packages/@logossim/components/Xor/XorWidget.jsx
@@ -121,7 +121,6 @@ const XorWidget = props => {
           <PositionedPort
             name={port.getName()}
             model={model}
-            port={port}
             engine={engine}
             position={portPositions[i]}
           />
@@ -133,12 +132,7 @@ const XorWidget = props => {
           )}
         </Fragment>
       ))}
-      <PositionedPort
-        name="out"
-        model={model}
-        port={model.getPort('out')}
-        engine={engine}
-      />
+      <PositionedPort name="out" model={model} engine={engine} />
       <Shape portPositions={portPositions} />
     </Wrapper>
   );

--- a/packages/@logossim/components/Xor/XorWidget.jsx
+++ b/packages/@logossim/components/Xor/XorWidget.jsx
@@ -104,7 +104,7 @@ export const Shape = ({ size = 90, portPositions = [] }) => (
 );
 
 const XorWidget = props => {
-  const { model, engine } = props;
+  const { model } = props;
 
   const inputPorts = Object.values(model.getInputPorts());
   const portPositions = distributePorts(inputPorts.length);
@@ -121,7 +121,6 @@ const XorWidget = props => {
           <PositionedPort
             name={port.getName()}
             model={model}
-            engine={engine}
             position={portPositions[i]}
           />
           {(portPositions[i] < 1 || portPositions[i] > 5) && (
@@ -132,7 +131,7 @@ const XorWidget = props => {
           )}
         </Fragment>
       ))}
-      <PositionedPort name="out" model={model} engine={engine} />
+      <PositionedPort name="out" model={model} />
       <Shape portPositions={portPositions} />
     </Wrapper>
   );

--- a/packages/@logossim/components/Xor/__tests__/XorModel.test.js
+++ b/packages/@logossim/components/Xor/__tests__/XorModel.test.js
@@ -2,348 +2,353 @@ import XorModel from '../XorModel';
 
 const { addPort } = global;
 
-it('should add ports on initialization', () => {
-  const addInputSpy = jest.spyOn(XorModel.prototype, 'addInputPort');
-  addInputSpy.mockImplementation(addPort);
+describe('XorModel', () => {
+  it('should add ports on initialization', () => {
+    const addInputSpy = jest.spyOn(
+      XorModel.prototype,
+      'addInputPort',
+    );
+    addInputSpy.mockImplementation(addPort);
 
-  const addOutputSpy = jest.spyOn(
-    XorModel.prototype,
-    'addOutputPort',
-  );
-  addOutputSpy.mockImplementation(addPort);
+    const addOutputSpy = jest.spyOn(
+      XorModel.prototype,
+      'addOutputPort',
+    );
+    addOutputSpy.mockImplementation(addPort);
 
-  new XorModel({
-    INPUT_PORTS_NUMBER: 16,
-    DATA_BITS: 1,
-  });
-
-  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
-  [...Array(16).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
-      bits: 1,
-    });
-  });
-});
-
-describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
-  it("should return 1 when there's only 1 high input", () => {
-    const model = new XorModel({
-      MULTIPLE_INPUT_BEHAVIOR: 'ONE',
-      INPUT_PORTS_NUMBER: 4,
+    new XorModel({
+      INPUT_PORTS_NUMBER: 16,
       DATA_BITS: 1,
     });
 
-    expect(
-      model.step({
-        in0: 1,
-        in1: 0,
-        in2: 0,
-        in3: 0,
-      }),
-    ).toEqual({ out: [1] });
-
-    expect(
-      model.step({
-        in0: 0,
-        in1: 1,
-        in2: 0,
-        in3: 0,
-      }),
-    ).toEqual({ out: [1] });
-
-    expect(
-      model.step({
-        in0: 0,
-        in1: 0,
-        in2: 1,
-        in3: 0,
-      }),
-    ).toEqual({ out: [1] });
-
-    expect(
-      model.step({
-        in0: 0,
-        in1: 0,
-        in2: 0,
-        in3: 1,
-      }),
-    ).toEqual({ out: [1] });
-
-    expect(
-      model.stepFloating({
-        in0: ['x'],
-        in1: [0],
-        in2: [0],
-        in3: [1],
-      }),
-    ).toEqual({ out: [1] });
-  });
-
-  it("should return 0 when there's more than 1 high input", () => {
-    const model = new XorModel({
-      MULTIPLE_INPUT_BEHAVIOR: 'ONE',
-      INPUT_PORTS_NUMBER: 4,
-      DATA_BITS: 1,
-    });
-
-    expect(
-      model.step({
-        in0: 1,
-        in1: 1,
-        in2: 0,
-        in3: 0,
-      }),
-    ).toEqual({ out: [0] });
-
-    expect(
-      model.step({
-        in0: 0,
-        in1: 1,
-        in2: 1,
-        in3: 0,
-      }),
-    ).toEqual({ out: [0] });
-
-    expect(
-      model.step({
-        in0: 0,
-        in1: 0,
-        in2: 1,
-        in3: 1,
-      }),
-    ).toEqual({ out: [0] });
-
-    expect(
-      model.step({
-        in0: 1,
-        in1: 0,
-        in2: 0,
-        in3: 1,
-      }),
-    ).toEqual({ out: [0] });
-
-    expect(
-      model.step({
-        in0: 1,
-        in1: 1,
-        in2: 1,
-        in3: 0,
-      }),
-    ).toEqual({ out: [0] });
-
-    expect(
-      model.step({
-        in0: 1,
-        in1: 1,
-        in2: 1,
-        in3: 1,
-      }),
-    ).toEqual({ out: [0] });
-
-    expect(
-      model.stepFloating({
-        in0: [1],
-        in1: [1],
-        in2: [1],
-        in3: ['x'],
-      }),
-    ).toEqual({ out: [0] });
-  });
-
-  it('should return 0 when all inputs are 0', () => {
-    const model = new XorModel({
-      MULTIPLE_INPUT_BEHAVIOR: 'ONE',
-      INPUT_PORTS_NUMBER: 4,
-      DATA_BITS: 1,
-    });
-
-    expect(
-      model.step({
-        in0: 0,
-        in1: 0,
-        in2: 0,
-        in3: 0,
-      }),
-    ).toEqual({ out: [0] });
-  });
-
-  it('should return bitwise XOR for multiple data bits', () => {
-    const DATA_BITS = 8;
-
-    const model = new XorModel({
-      MULTIPLE_INPUT_BEHAVIOR: 'ONE',
-      INPUT_PORTS_NUMBER: 5,
-      DATA_BITS,
-    });
-
-    expect(
-      model.step({
-        in0: 0b0110_1000,
-        in1: 0b0100_0100,
-        in2: 0b0111_0010,
-        in3: 0b0101_0001,
-      }),
-    ).toEqual({
-      out: (0b0000_1111).asArray(DATA_BITS),
+    expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
+    [...Array(16).keys()].forEach(i => {
+      expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
+        bits: 1,
+      });
     });
   });
-});
 
-describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
-  it("should return 1 when there's an odd number of high inputs", () => {
-    const model = new XorModel({
-      MULTIPLE_INPUT_BEHAVIOR: 'ODD',
-      INPUT_PORTS_NUMBER: 5,
-      DATA_BITS: 1,
+  describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
+    it("should return 1 when there's only 1 high input", () => {
+      const model = new XorModel({
+        MULTIPLE_INPUT_BEHAVIOR: 'ONE',
+        INPUT_PORTS_NUMBER: 4,
+        DATA_BITS: 1,
+      });
+
+      expect(
+        model.step({
+          in0: 1,
+          in1: 0,
+          in2: 0,
+          in3: 0,
+        }),
+      ).toEqual({ out: [1] });
+
+      expect(
+        model.step({
+          in0: 0,
+          in1: 1,
+          in2: 0,
+          in3: 0,
+        }),
+      ).toEqual({ out: [1] });
+
+      expect(
+        model.step({
+          in0: 0,
+          in1: 0,
+          in2: 1,
+          in3: 0,
+        }),
+      ).toEqual({ out: [1] });
+
+      expect(
+        model.step({
+          in0: 0,
+          in1: 0,
+          in2: 0,
+          in3: 1,
+        }),
+      ).toEqual({ out: [1] });
+
+      expect(
+        model.stepFloating({
+          in0: ['x'],
+          in1: [0],
+          in2: [0],
+          in3: [1],
+        }),
+      ).toEqual({ out: [1] });
     });
 
-    expect(
-      model.step({
-        in0: 1,
-        in1: 0,
-        in2: 0,
-        in3: 0,
-        in4: 0,
-      }),
-    ).toEqual({ out: [1] });
+    it("should return 0 when there's more than 1 high input", () => {
+      const model = new XorModel({
+        MULTIPLE_INPUT_BEHAVIOR: 'ONE',
+        INPUT_PORTS_NUMBER: 4,
+        DATA_BITS: 1,
+      });
 
-    expect(
-      model.step({
-        in0: 1,
-        in1: 1,
-        in2: 1,
-        in3: 0,
-        in4: 0,
-      }),
-    ).toEqual({ out: [1] });
+      expect(
+        model.step({
+          in0: 1,
+          in1: 1,
+          in2: 0,
+          in3: 0,
+        }),
+      ).toEqual({ out: [0] });
 
-    expect(
-      model.step({
-        in0: 1,
-        in1: 1,
-        in2: 1,
-        in3: 1,
-        in4: 1,
-      }),
-    ).toEqual({ out: [1] });
+      expect(
+        model.step({
+          in0: 0,
+          in1: 1,
+          in2: 1,
+          in3: 0,
+        }),
+      ).toEqual({ out: [0] });
 
-    expect(
-      model.stepFloating({
-        in0: [0],
-        in1: [1],
-        in2: ['x'],
-        in3: [0],
-      }),
-    ).toEqual({ out: [1] });
+      expect(
+        model.step({
+          in0: 0,
+          in1: 0,
+          in2: 1,
+          in3: 1,
+        }),
+      ).toEqual({ out: [0] });
 
-    expect(
-      model.stepFloating({
-        in0: [1],
-        in1: [1],
-        in2: ['x'],
-        in3: [1],
-      }),
-    ).toEqual({ out: [1] });
+      expect(
+        model.step({
+          in0: 1,
+          in1: 0,
+          in2: 0,
+          in3: 1,
+        }),
+      ).toEqual({ out: [0] });
+
+      expect(
+        model.step({
+          in0: 1,
+          in1: 1,
+          in2: 1,
+          in3: 0,
+        }),
+      ).toEqual({ out: [0] });
+
+      expect(
+        model.step({
+          in0: 1,
+          in1: 1,
+          in2: 1,
+          in3: 1,
+        }),
+      ).toEqual({ out: [0] });
+
+      expect(
+        model.stepFloating({
+          in0: [1],
+          in1: [1],
+          in2: [1],
+          in3: ['x'],
+        }),
+      ).toEqual({ out: [0] });
+    });
+
+    it('should return 0 when all inputs are 0', () => {
+      const model = new XorModel({
+        MULTIPLE_INPUT_BEHAVIOR: 'ONE',
+        INPUT_PORTS_NUMBER: 4,
+        DATA_BITS: 1,
+      });
+
+      expect(
+        model.step({
+          in0: 0,
+          in1: 0,
+          in2: 0,
+          in3: 0,
+        }),
+      ).toEqual({ out: [0] });
+    });
+
+    it('should return bitwise XOR for multiple data bits', () => {
+      const DATA_BITS = 8;
+
+      const model = new XorModel({
+        MULTIPLE_INPUT_BEHAVIOR: 'ONE',
+        INPUT_PORTS_NUMBER: 5,
+        DATA_BITS,
+      });
+
+      expect(
+        model.step({
+          in0: 0b0110_1000,
+          in1: 0b0100_0100,
+          in2: 0b0111_0010,
+          in3: 0b0101_0001,
+        }),
+      ).toEqual({
+        out: (0b0000_1111).asArray(DATA_BITS),
+      });
+    });
   });
 
-  it("should return 0 when there's an odd number of high inputs", () => {
-    const model = new XorModel({
-      MULTIPLE_INPUT_BEHAVIOR: 'ODD',
-      INPUT_PORTS_NUMBER: 4,
-      DATA_BITS: 1,
+  describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
+    it("should return 1 when there's an odd number of high inputs", () => {
+      const model = new XorModel({
+        MULTIPLE_INPUT_BEHAVIOR: 'ODD',
+        INPUT_PORTS_NUMBER: 5,
+        DATA_BITS: 1,
+      });
+
+      expect(
+        model.step({
+          in0: 1,
+          in1: 0,
+          in2: 0,
+          in3: 0,
+          in4: 0,
+        }),
+      ).toEqual({ out: [1] });
+
+      expect(
+        model.step({
+          in0: 1,
+          in1: 1,
+          in2: 1,
+          in3: 0,
+          in4: 0,
+        }),
+      ).toEqual({ out: [1] });
+
+      expect(
+        model.step({
+          in0: 1,
+          in1: 1,
+          in2: 1,
+          in3: 1,
+          in4: 1,
+        }),
+      ).toEqual({ out: [1] });
+
+      expect(
+        model.stepFloating({
+          in0: [0],
+          in1: [1],
+          in2: ['x'],
+          in3: [0],
+        }),
+      ).toEqual({ out: [1] });
+
+      expect(
+        model.stepFloating({
+          in0: [1],
+          in1: [1],
+          in2: ['x'],
+          in3: [1],
+        }),
+      ).toEqual({ out: [1] });
     });
 
-    expect(
-      model.step({
-        in0: 0,
-        in1: 0,
-        in2: 0,
-        in3: 0,
-      }),
-    ).toEqual({ out: [0] });
+    it("should return 0 when there's an odd number of high inputs", () => {
+      const model = new XorModel({
+        MULTIPLE_INPUT_BEHAVIOR: 'ODD',
+        INPUT_PORTS_NUMBER: 4,
+        DATA_BITS: 1,
+      });
 
-    expect(
-      model.step({
-        in0: 1,
-        in1: 1,
-        in2: 0,
-        in3: 0,
-      }),
-    ).toEqual({ out: [0] });
+      expect(
+        model.step({
+          in0: 0,
+          in1: 0,
+          in2: 0,
+          in3: 0,
+        }),
+      ).toEqual({ out: [0] });
 
-    expect(
-      model.step({
-        in0: 0,
-        in1: 1,
-        in2: 1,
-        in3: 0,
-      }),
-    ).toEqual({ out: [0] });
+      expect(
+        model.step({
+          in0: 1,
+          in1: 1,
+          in2: 0,
+          in3: 0,
+        }),
+      ).toEqual({ out: [0] });
 
-    expect(
-      model.step({
-        in0: 0,
-        in1: 0,
-        in2: 1,
-        in3: 1,
-      }),
-    ).toEqual({ out: [0] });
+      expect(
+        model.step({
+          in0: 0,
+          in1: 1,
+          in2: 1,
+          in3: 0,
+        }),
+      ).toEqual({ out: [0] });
 
-    expect(
-      model.step({
-        in0: 1,
-        in1: 0,
-        in2: 0,
-        in3: 1,
-      }),
-    ).toEqual({ out: [0] });
+      expect(
+        model.step({
+          in0: 0,
+          in1: 0,
+          in2: 1,
+          in3: 1,
+        }),
+      ).toEqual({ out: [0] });
 
-    expect(
-      model.step({
-        in0: 1,
-        in1: 1,
-        in2: 1,
-        in3: 1,
-      }),
-    ).toEqual({ out: [0] });
+      expect(
+        model.step({
+          in0: 1,
+          in1: 0,
+          in2: 0,
+          in3: 1,
+        }),
+      ).toEqual({ out: [0] });
 
-    expect(
-      model.stepFloating({
-        in0: [0],
-        in1: [0],
-        in2: ['x'],
-        in3: [0],
-      }),
-    ).toEqual({ out: [0] });
+      expect(
+        model.step({
+          in0: 1,
+          in1: 1,
+          in2: 1,
+          in3: 1,
+        }),
+      ).toEqual({ out: [0] });
 
-    expect(
-      model.stepFloating({
-        in0: [0],
-        in1: [1],
-        in2: ['x'],
-        in3: [1],
-      }),
-    ).toEqual({ out: [0] });
-  });
+      expect(
+        model.stepFloating({
+          in0: [0],
+          in1: [0],
+          in2: ['x'],
+          in3: [0],
+        }),
+      ).toEqual({ out: [0] });
 
-  it('should return bitwise XOR for multiple data bits', () => {
-    const DATA_BITS = 8;
-
-    const model = new XorModel({
-      MULTIPLE_INPUT_BEHAVIOR: 'ODD',
-      INPUT_PORTS_NUMBER: 4,
-      DATA_BITS,
+      expect(
+        model.stepFloating({
+          in0: [0],
+          in1: [1],
+          in2: ['x'],
+          in3: [1],
+        }),
+      ).toEqual({ out: [0] });
     });
 
-    expect(
-      model.step({
-        in0: 0b0000_0000,
-        in1: 0b0111_1000,
-        in2: 0b0110_0110,
-        in3: 0b0101_0101,
-      }),
-    ).toEqual({
-      out: (0b0100_1011).asArray(DATA_BITS),
+    it('should return bitwise XOR for multiple data bits', () => {
+      const DATA_BITS = 8;
+
+      const model = new XorModel({
+        MULTIPLE_INPUT_BEHAVIOR: 'ODD',
+        INPUT_PORTS_NUMBER: 4,
+        DATA_BITS,
+      });
+
+      expect(
+        model.step({
+          in0: 0b0000_0000,
+          in1: 0b0111_1000,
+          in2: 0b0110_0110,
+          in3: 0b0101_0101,
+        }),
+      ).toEqual({
+        out: (0b0100_1011).asArray(DATA_BITS),
+      });
     });
   });
 });

--- a/packages/@logossim/components/Xor/__tests__/XorModel.test.js
+++ b/packages/@logossim/components/Xor/__tests__/XorModel.test.js
@@ -34,7 +34,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 0,
         in2: 0,
@@ -43,7 +43,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     ).toEqual({ out: [1] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 1,
         in2: 0,
@@ -52,7 +52,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     ).toEqual({ out: [1] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 0,
         in2: 1,
@@ -61,11 +61,20 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     ).toEqual({ out: [1] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 0,
         in2: 0,
         in3: 1,
+      }),
+    ).toEqual({ out: [1] });
+
+    expect(
+      model.stepFloating({
+        in0: ['x'],
+        in1: [0],
+        in2: [0],
+        in3: [1],
       }),
     ).toEqual({ out: [1] });
   });
@@ -78,7 +87,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 1,
         in2: 0,
@@ -87,7 +96,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     ).toEqual({ out: [0] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 1,
         in2: 1,
@@ -96,7 +105,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     ).toEqual({ out: [0] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 0,
         in2: 1,
@@ -105,7 +114,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     ).toEqual({ out: [0] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 0,
         in2: 0,
@@ -114,7 +123,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     ).toEqual({ out: [0] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 1,
         in2: 1,
@@ -123,11 +132,20 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     ).toEqual({ out: [0] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 1,
         in2: 1,
         in3: 1,
+      }),
+    ).toEqual({ out: [0] });
+
+    expect(
+      model.stepFloating({
+        in0: [1],
+        in1: [1],
+        in2: [1],
+        in3: ['x'],
       }),
     ).toEqual({ out: [0] });
   });
@@ -140,7 +158,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 0,
         in2: 0,
@@ -159,7 +177,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
     });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0b0110_1000,
         in1: 0b0100_0100,
         in2: 0b0111_0010,
@@ -180,7 +198,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 0,
         in2: 0,
@@ -190,7 +208,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     ).toEqual({ out: [1] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 1,
         in2: 1,
@@ -200,12 +218,30 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     ).toEqual({ out: [1] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 1,
         in2: 1,
         in3: 1,
         in4: 1,
+      }),
+    ).toEqual({ out: [1] });
+
+    expect(
+      model.stepFloating({
+        in0: [0],
+        in1: [1],
+        in2: ['x'],
+        in3: [0],
+      }),
+    ).toEqual({ out: [1] });
+
+    expect(
+      model.stepFloating({
+        in0: [1],
+        in1: [1],
+        in2: ['x'],
+        in3: [1],
       }),
     ).toEqual({ out: [1] });
   });
@@ -218,7 +254,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 0,
         in2: 0,
@@ -227,7 +263,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     ).toEqual({ out: [0] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 1,
         in2: 0,
@@ -236,7 +272,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     ).toEqual({ out: [0] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 1,
         in2: 1,
@@ -245,7 +281,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     ).toEqual({ out: [0] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0,
         in1: 0,
         in2: 1,
@@ -254,7 +290,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     ).toEqual({ out: [0] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 0,
         in2: 0,
@@ -263,11 +299,29 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
     ).toEqual({ out: [0] });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 1,
         in1: 1,
         in2: 1,
         in3: 1,
+      }),
+    ).toEqual({ out: [0] });
+
+    expect(
+      model.stepFloating({
+        in0: [0],
+        in1: [0],
+        in2: ['x'],
+        in3: [0],
+      }),
+    ).toEqual({ out: [0] });
+
+    expect(
+      model.stepFloating({
+        in0: [0],
+        in1: [1],
+        in2: ['x'],
+        in3: [1],
       }),
     ).toEqual({ out: [0] });
   });
@@ -277,12 +331,12 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
 
     const model = new XorModel({
       MULTIPLE_INPUT_BEHAVIOR: 'ODD',
-      INPUT_PORTS_NUMBER: 5,
+      INPUT_PORTS_NUMBER: 4,
       DATA_BITS,
     });
 
     expect(
-      model.stepAndMask({
+      model.step({
         in0: 0b0000_0000,
         in1: 0b0111_1000,
         in2: 0b0110_0110,

--- a/packages/@logossim/components/Xor/__tests__/XorModel.test.js
+++ b/packages/@logossim/components/Xor/__tests__/XorModel.test.js
@@ -20,9 +20,11 @@ it('should add ports on initialization', () => {
     DATA_BITS: 1,
   });
 
-  expect(addOutputSpy).toHaveBeenCalledWith('out', 1);
+  expect(addOutputSpy).toHaveBeenCalledWith('out', { bits: 1 });
   [...Array(16).keys()].forEach(i => {
-    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, 1);
+    expect(addInputSpy).toHaveBeenNthCalledWith(i + 1, `in${i}`, {
+      bits: 1,
+    });
   });
 });
 

--- a/packages/@logossim/components/Xor/__tests__/XorModel.test.js
+++ b/packages/@logossim/components/Xor/__tests__/XorModel.test.js
@@ -1,6 +1,3 @@
-/* eslint-disable no-new */
-import { convertNumberValueToArray } from '@logossim/core/Simulation/utils';
-
 import XorModel from '../XorModel';
 
 const { addPort } = global;
@@ -169,7 +166,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ONE', () => {
         in3: 0b0101_0001,
       }),
     ).toEqual({
-      out: convertNumberValueToArray(0b0000_1111, DATA_BITS),
+      out: (0b0000_1111).asArray(DATA_BITS),
     });
   });
 });
@@ -292,7 +289,7 @@ describe('Configured with MULTIPLE_INPUT_BEHAVIOR=ODD', () => {
         in3: 0b0101_0101,
       }),
     ).toEqual({
-      out: convertNumberValueToArray(0b0100_1011, DATA_BITS),
+      out: (0b0100_1011).asArray(DATA_BITS),
     });
   });
 });

--- a/packages/@logossim/components/Xor/__tests__/XorWidget.test.jsx
+++ b/packages/@logossim/components/Xor/__tests__/XorWidget.test.jsx
@@ -1,29 +1,30 @@
 import React from 'react';
 
 import { render } from '../../testUtils';
-
 import XorModel from '../XorModel';
 import XorWidget from '../XorWidget';
 
-it('should have 1 output port', () => {
-  const model = new XorModel({
-    DATA_BITS: 1,
+describe('XorWidget', () => {
+  it('should have 1 output port', () => {
+    const model = new XorModel({
+      DATA_BITS: 1,
+    });
+
+    const { container } = render(<XorWidget model={model} />);
+
+    const ports = container.querySelectorAll('[data-name=out]');
+    expect(ports).toHaveLength(1);
   });
 
-  const { container } = render(<XorWidget model={model} />);
+  it('should have the amount of input ports determined by configuration', () => {
+    const model = new XorModel({
+      INPUT_PORTS_NUMBER: 16,
+      DATA_BITS: 1,
+    });
 
-  const ports = container.querySelectorAll('[data-name=out]');
-  expect(ports).toHaveLength(1);
-});
+    const { container } = render(<XorWidget model={model} />);
 
-it('should have the amount of input ports determined by configuration', () => {
-  const model = new XorModel({
-    INPUT_PORTS_NUMBER: 16,
-    DATA_BITS: 1,
+    const ports = container.querySelectorAll('[data-name^=in]');
+    expect(ports).toHaveLength(16);
   });
-
-  const { container } = render(<XorWidget model={model} />);
-
-  const ports = container.querySelectorAll('[data-name^=in]');
-  expect(ports).toHaveLength(16);
 });

--- a/packages/@logossim/components/Xor/__tests__/XorWidget.test.jsx
+++ b/packages/@logossim/components/Xor/__tests__/XorWidget.test.jsx
@@ -1,20 +1,16 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render } from '../../testUtils';
 
 import XorModel from '../XorModel';
 import XorWidget from '../XorWidget';
-
-const { engine } = global;
 
 it('should have 1 output port', () => {
   const model = new XorModel({
     DATA_BITS: 1,
   });
 
-  const { container } = render(
-    <XorWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<XorWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name=out]');
   expect(ports).toHaveLength(1);
@@ -26,9 +22,7 @@ it('should have the amount of input ports determined by configuration', () => {
     DATA_BITS: 1,
   });
 
-  const { container } = render(
-    <XorWidget model={model} engine={engine} />,
-  );
+  const { container } = render(<XorWidget model={model} />);
 
   const ports = container.querySelectorAll('[data-name^=in]');
   expect(ports).toHaveLength(16);

--- a/packages/@logossim/components/index.js
+++ b/packages/@logossim/components/index.js
@@ -19,6 +19,7 @@ import Or from './Or/OrRegister';
 import Output from './Output/OutputRegister';
 import Power from './Power/PowerRegister';
 import Ram from './Ram/RamRegister';
+import Rom from './Rom/RomRegister';
 import Splitter from './Splitter/SplitterRegister';
 import Ssd from './Ssd/SsdRegister';
 import Switch from './Switch/SwitchRegister';
@@ -51,6 +52,7 @@ const components = [
   Mux,
   Demux,
   Ram,
+  Rom,
   Counter,
 ];
 

--- a/packages/@logossim/components/index.js
+++ b/packages/@logossim/components/index.js
@@ -5,6 +5,7 @@ import Buzzer from './Buzzer/BuzzerRegister';
 import Clock from './Clock/ClockRegister';
 import ControlledBuffer from './ControlledBuffer/ControlledBufferRegister';
 import ControlledInverter from './ControlledInverter/ControlledInverterRegister';
+import Counter from './Counter/CounterRegister';
 import Demux from './Demux/DemuxRegister';
 import Ground from './Ground/GroundRegister';
 import Input from './Input/InputRegister';
@@ -49,6 +50,8 @@ const components = [
   Ground,
   Mux,
   Demux,
+  Ram,
+  Counter,
 ];
 
 export default components;

--- a/packages/@logossim/components/index.js
+++ b/packages/@logossim/components/index.js
@@ -17,6 +17,7 @@ import Not from './Not/NotRegister';
 import Or from './Or/OrRegister';
 import Output from './Output/OutputRegister';
 import Power from './Power/PowerRegister';
+import Ram from './Ram/RamRegister';
 import Splitter from './Splitter/SplitterRegister';
 import Ssd from './Ssd/SsdRegister';
 import Switch from './Switch/SwitchRegister';

--- a/packages/@logossim/components/testUtils.js
+++ b/packages/@logossim/components/testUtils.js
@@ -1,32 +1,36 @@
 import React from 'react';
 
+import ComponentContext from '@logossim/core/ComponentContext';
 import DiagramContext from '@logossim/core/Diagram/DiagramContext';
 
 import { render } from '@testing-library/react';
 
-const Wrapper = ({ children }) => {
-  return (
-    <DiagramContext.Provider
-      value={{
-        getEngine: () => ({
-          registerListener: () => {},
-          getCanvas: () => {},
-          getPortCoords: () => ({
-            getWidth: () => {},
-            getHeight: () => {},
-            getTopLeft: () => {},
-          }),
-          getModel: () => ({ isLocked: () => false }),
+const Wrapper = ({ children, model }) => (
+  <DiagramContext.Provider
+    value={{
+      getEngine: () => ({
+        registerListener: () => {},
+        getCanvas: () => {},
+        getPortCoords: () => ({
+          getWidth: () => {},
+          getHeight: () => {},
+          getTopLeft: () => {},
         }),
-      }}
-    >
+        getModel: () => ({ isLocked: () => false }),
+      }),
+    }}
+  >
+    <ComponentContext.Provider value={model}>
       {children}
-    </DiagramContext.Provider>
-  );
-};
+    </ComponentContext.Provider>
+  </DiagramContext.Provider>
+);
 
 const customRender = (ui, options) =>
-  render(ui, { wrapper: Wrapper, ...options });
+  render(ui, {
+    wrapper: props => <Wrapper {...props} model={ui.props.model} />,
+    ...options,
+  });
 
 // re-export everything
 export * from '@testing-library/react';

--- a/packages/@logossim/components/testUtils.js
+++ b/packages/@logossim/components/testUtils.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import DiagramContext from '@logossim/core/Diagram/DiagramContext';
+
+import { render } from '@testing-library/react';
+
+const Wrapper = ({ children }) => {
+  return (
+    <DiagramContext.Provider
+      value={{
+        getEngine: () => ({
+          registerListener: () => {},
+          getCanvas: () => {},
+          getPortCoords: () => ({
+            getWidth: () => {},
+            getHeight: () => {},
+            getTopLeft: () => {},
+          }),
+          getModel: () => ({ isLocked: () => false }),
+        }),
+      }}
+    >
+      {children}
+    </DiagramContext.Provider>
+  );
+};
+
+const customRender = (ui, options) =>
+  render(ui, { wrapper: Wrapper, ...options });
+
+// re-export everything
+export * from '@testing-library/react';
+
+// override render method
+export { customRender as render };

--- a/packages/@logossim/core/BaseModel.js
+++ b/packages/@logossim/core/BaseModel.js
@@ -2,7 +2,6 @@ import { Point } from '@projectstorm/geometry';
 import { NodeModel } from '@projectstorm/react-diagrams';
 
 import PortModel from './Port/PortModel';
-import { DEFAULT_PORT_CONFIGURATION } from './Simulation/const';
 import { emit } from './Simulation/SimulationEngine';
 import {
   adjustValueToBits,
@@ -31,30 +30,38 @@ export default class BaseModel extends NodeModel {
     };
   }
 
-  addInputPort(name, { bits = 1 } = DEFAULT_PORT_CONFIGURATION) {
+  addInputPort(name, { bits, floating, error } = {}) {
     const port = getPort(name);
     port.setAsInput();
-    if (typeof name === 'string') port.setBits(bits);
+    if (typeof name === 'string') {
+      port.setBits(bits || 1);
+      port.setDefaultFloatingValue(floating || 'x');
+      port.setDefaultErrorValue(error || 'e');
+    }
     super.addPort(port);
   }
 
-  addOutputPort(name, { bits = 1 } = DEFAULT_PORT_CONFIGURATION) {
+  addOutputPort(name, { bits } = {}) {
     const port = getPort(name);
     port.setAsOutput();
-    if (typeof name === 'string') port.setBits(bits);
+    if (typeof name === 'string') {
+      port.setBits(bits || 1);
+      port.setDefaultFloatingValue('x');
+      port.setDefaultErrorValue('e');
+    }
     super.addPort(port);
   }
 
-  addPort(name, { bits = 1 } = DEFAULT_PORT_CONFIGURATION) {
+  addPort(name, configuration) {
     const port = getPort(name);
 
     if (port.isInput()) {
-      this.addInputPort(port, bits);
+      this.addInputPort(port, configuration);
       return;
     }
 
     if (port.isOutput()) {
-      this.addOutputPort(port, bits);
+      this.addOutputPort(port, configuration);
       return;
     }
 

--- a/packages/@logossim/core/BaseModel.js
+++ b/packages/@logossim/core/BaseModel.js
@@ -3,7 +3,6 @@ import { NodeModel } from '@projectstorm/react-diagrams';
 
 import PortModel from './Port/PortModel';
 import { emit } from './Simulation/SimulationEngine';
-import { adjustValueToBits, isValueValid } from './Simulation/utils';
 
 const getPort = nameOrInstance => {
   if (nameOrInstance instanceof PortModel) return nameOrInstance;

--- a/packages/@logossim/core/BaseModel.js
+++ b/packages/@logossim/core/BaseModel.js
@@ -3,15 +3,11 @@ import { NodeModel } from '@projectstorm/react-diagrams';
 
 import PortModel from './Port/PortModel';
 import { emit } from './Simulation/SimulationEngine';
-import {
-  adjustValueToBits,
-  convertNumberValueToArray,
-  isValueValid,
-} from './Simulation/utils';
+import { adjustValueToBits, isValueValid } from './Simulation/utils';
 
-const getPort = port => {
-  if (port instanceof PortModel) return port;
-  return new PortModel({ name: port });
+const getPort = nameOrInstance => {
+  if (nameOrInstance instanceof PortModel) return nameOrInstance;
+  return new PortModel({ name: nameOrInstance });
 };
 
 export default class BaseModel extends NodeModel {
@@ -30,10 +26,10 @@ export default class BaseModel extends NodeModel {
     };
   }
 
-  addInputPort(name, { bits, floating, error } = {}) {
-    const port = getPort(name);
+  addInputPort(nameOrInstance, { bits, floating, error } = {}) {
+    const port = getPort(nameOrInstance);
     port.setAsInput();
-    if (typeof name === 'string') {
+    if (typeof nameOrInstance === 'string') {
       port.setBits(bits || 1);
       port.setDefaultFloatingValue(floating ?? 'x');
       port.setDefaultErrorValue(error ?? 'e');
@@ -41,10 +37,10 @@ export default class BaseModel extends NodeModel {
     super.addPort(port);
   }
 
-  addOutputPort(name, { bits } = {}) {
-    const port = getPort(name);
+  addOutputPort(nameOrInstance, { bits } = {}) {
+    const port = getPort(nameOrInstance);
     port.setAsOutput();
-    if (typeof name === 'string') {
+    if (typeof nameOrInstance === 'string') {
       port.setBits(bits || 1);
       port.setDefaultFloatingValue('x');
       port.setDefaultErrorValue('e');
@@ -52,8 +48,8 @@ export default class BaseModel extends NodeModel {
     super.addPort(port);
   }
 
-  addPort(name, configuration) {
-    const port = getPort(name);
+  addPort(nameOrInstance, configuration) {
+    const port = getPort(nameOrInstance);
 
     if (port.isInput()) {
       this.addInputPort(port, configuration);
@@ -132,10 +128,7 @@ export default class BaseModel extends NodeModel {
         const { bits } = this.getPort(portName);
         let value = portValue;
         if (typeof value === 'number') {
-          value = convertNumberValueToArray(
-            adjustValueToBits(portValue, bits),
-            bits,
-          );
+          value = adjustValueToBits(portValue, bits).asArray(bits);
         } else if (value === 'x' || value === 'e') {
           value = Array(bits).fill(value);
         }

--- a/packages/@logossim/core/BaseModel.js
+++ b/packages/@logossim/core/BaseModel.js
@@ -2,6 +2,7 @@ import { Point } from '@projectstorm/geometry';
 import { NodeModel } from '@projectstorm/react-diagrams';
 
 import PortModel from './Port/PortModel';
+import { DEFAULT_PORT_CONFIGURATION } from './Simulation/const';
 import { emit } from './Simulation/SimulationEngine';
 import {
   adjustValueToBits,
@@ -30,22 +31,22 @@ export default class BaseModel extends NodeModel {
     };
   }
 
-  addInputPort(arg, bits = 1) {
-    const port = getPort(arg);
+  addInputPort(name, { bits = 1 } = DEFAULT_PORT_CONFIGURATION) {
+    const port = getPort(name);
     port.setAsInput();
-    if (typeof arg === 'string') port.setBits(bits);
+    if (typeof name === 'string') port.setBits(bits);
     super.addPort(port);
   }
 
-  addOutputPort(arg, bits = 1) {
-    const port = getPort(arg);
+  addOutputPort(name, { bits = 1 } = DEFAULT_PORT_CONFIGURATION) {
+    const port = getPort(name);
     port.setAsOutput();
-    if (typeof arg === 'string') port.setBits(bits);
+    if (typeof name === 'string') port.setBits(bits);
     super.addPort(port);
   }
 
-  addPort(arg, bits = 1) {
-    const port = getPort(arg);
+  addPort(name, { bits = 1 } = DEFAULT_PORT_CONFIGURATION) {
+    const port = getPort(name);
 
     if (port.isInput()) {
       this.addInputPort(port, bits);
@@ -62,8 +63,8 @@ export default class BaseModel extends NodeModel {
     );
   }
 
-  removePort(arg) {
-    const port = getPort(arg);
+  removePort(name) {
+    const port = getPort(name);
     super.removePort(port);
   }
 

--- a/packages/@logossim/core/BaseModel.js
+++ b/packages/@logossim/core/BaseModel.js
@@ -35,8 +35,8 @@ export default class BaseModel extends NodeModel {
     port.setAsInput();
     if (typeof name === 'string') {
       port.setBits(bits || 1);
-      port.setDefaultFloatingValue(floating || 'x');
-      port.setDefaultErrorValue(error || 'e');
+      port.setDefaultFloatingValue(floating ?? 'x');
+      port.setDefaultErrorValue(error ?? 'e');
     }
     super.addPort(port);
   }

--- a/packages/@logossim/core/BaseModel.js
+++ b/packages/@logossim/core/BaseModel.js
@@ -117,27 +117,5 @@ export default class BaseModel extends NodeModel {
     emit(this.getID(), value);
   }
 
-  // Methods to facilitate unit testing
   createAudio() {}
-
-  stepAndMask(input) {
-    const stepResult = this.step(input);
-
-    return Object.fromEntries(
-      Object.entries(stepResult).map(([portName, portValue]) => {
-        const { bits } = this.getPort(portName);
-        let value = portValue;
-        if (typeof value === 'number') {
-          value = adjustValueToBits(portValue, bits).asArray(bits);
-        } else if (value === 'x' || value === 'e') {
-          value = Array(bits).fill(value);
-        }
-
-        return [
-          portName,
-          isValueValid(value, bits) ? value : Array(bits).fill('e'),
-        ];
-      }),
-    );
-  }
 }

--- a/packages/@logossim/core/Component.jsx
+++ b/packages/@logossim/core/Component.jsx
@@ -3,6 +3,8 @@ import { MenuProvider } from 'react-contexify';
 
 import { AbstractReactFactory } from '@projectstorm/react-canvas-core';
 
+import ComponentContext from './ComponentContext';
+
 export default class Component extends AbstractReactFactory {
   constructor({
     type,
@@ -30,7 +32,9 @@ export default class Component extends AbstractReactFactory {
 
     return (
       <MenuProvider id="component" storeRef={false} data={model}>
-        <Widget engine={this.engine} model={model} />
+        <ComponentContext.Provider value={model}>
+          <Widget model={model} />
+        </ComponentContext.Provider>
       </MenuProvider>
     );
   }

--- a/packages/@logossim/core/ComponentContext.jsx
+++ b/packages/@logossim/core/ComponentContext.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const ComponentContext = React.createContext();
+
+export default ComponentContext;

--- a/packages/@logossim/core/Diagram/Diagram.jsx
+++ b/packages/@logossim/core/Diagram/Diagram.jsx
@@ -5,6 +5,7 @@ import { CanvasWidget } from '@projectstorm/react-canvas-core';
 
 import styled from 'styled-components';
 
+import DiagramContext from './DiagramContext';
 import DroppableLayer from './DroppableLayer';
 
 const FullscreenCanvas = styled(CanvasWidget)`
@@ -20,7 +21,9 @@ const Diagram = ({ engine }) => (
       }
       disabled={engine.isLocked()}
     >
-      <FullscreenCanvas engine={engine.getEngine()} />
+      <DiagramContext.Provider value={engine}>
+        <FullscreenCanvas engine={engine.getEngine()} />
+      </DiagramContext.Provider>
     </DroppableLayer>
   </MenuProvider>
 );

--- a/packages/@logossim/core/Diagram/DiagramContext.jsx
+++ b/packages/@logossim/core/Diagram/DiagramContext.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const DiagramContext = React.createContext();
+
+export default DiagramContext;

--- a/packages/@logossim/core/Link/LinkModel.js
+++ b/packages/@logossim/core/Link/LinkModel.js
@@ -8,7 +8,6 @@ import { DefaultLabelModel } from '@projectstorm/react-diagrams-defaults';
 
 import { sameAxis } from '../Diagram/states/common';
 import {
-  convertArrayValueToNumber,
   isValueError,
   isValueValid,
   MAX_VALUE,
@@ -276,8 +275,7 @@ export default class LinkModel extends RDLinkModel {
       return `var(--link-${this.bits || 1}-bit-color)`;
 
     return `var(--value-${Math.round(
-      (convertArrayValueToNumber(this.value) / MAX_VALUE[this.bits]) *
-        10,
+      (this.value.asNumber() / MAX_VALUE[this.bits]) * 10,
     )})`;
   }
 

--- a/packages/@logossim/core/Port/Port.jsx
+++ b/packages/@logossim/core/Port/Port.jsx
@@ -20,7 +20,7 @@ const Circle = styled.div`
   }
 `;
 
-export default class Port extends PortWidget {
+class Port extends PortWidget {
   report() {
     if (this.props.port) super.report();
   }
@@ -30,7 +30,7 @@ export default class Port extends PortWidget {
   }
 
   render() {
-    const { name, model, port, className = '' } = this.props;
+    const { name, port, model, className = '' } = this.props;
 
     if (!port) return null;
 
@@ -45,3 +45,16 @@ export default class Port extends PortWidget {
     );
   }
 }
+
+/**
+ * React Diagrams PortWidget implementation needs us to forward some
+ * props in order to function properly.
+ */
+const withProps = WrappedComponent => ({ ...props }) => (
+  <WrappedComponent
+    {...props}
+    port={props.model.getPort(props.name)}
+  />
+);
+
+export default withProps(Port);

--- a/packages/@logossim/core/Port/Port.jsx
+++ b/packages/@logossim/core/Port/Port.jsx
@@ -4,6 +4,7 @@ import { PortWidget } from '@projectstorm/react-diagrams';
 
 import styled from 'styled-components';
 
+import ComponentContext from '../ComponentContext';
 import DiagramContext from '../Diagram/DiagramContext';
 
 const Circle = styled.div`
@@ -55,12 +56,14 @@ class Port extends PortWidget {
  */
 const withProps = WrappedComponent => ({ ...props }) => {
   const diagram = useContext(DiagramContext);
+  const model = useContext(ComponentContext);
 
   return (
     <WrappedComponent
       {...props}
-      port={props.model.getPort(props.name)}
+      port={model.getPort(props.name)}
       engine={diagram.getEngine()}
+      model={model}
     />
   );
 };

--- a/packages/@logossim/core/Port/Port.jsx
+++ b/packages/@logossim/core/Port/Port.jsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 import { PortWidget } from '@projectstorm/react-diagrams';
 
 import styled from 'styled-components';
+
+import DiagramContext from '../Diagram/DiagramContext';
 
 const Circle = styled.div`
   width: 10px;
@@ -48,13 +50,19 @@ class Port extends PortWidget {
 
 /**
  * React Diagrams PortWidget implementation needs us to forward some
- * props in order to function properly.
+ * props in order to function properly. We have this HOC so that
+ * component widgets don't need to pass them every time.
  */
-const withProps = WrappedComponent => ({ ...props }) => (
-  <WrappedComponent
-    {...props}
-    port={props.model.getPort(props.name)}
-  />
-);
+const withProps = WrappedComponent => ({ ...props }) => {
+  const diagram = useContext(DiagramContext);
+
+  return (
+    <WrappedComponent
+      {...props}
+      port={props.model.getPort(props.name)}
+      engine={diagram.getEngine()}
+    />
+  );
+};
 
 export default withProps(Port);

--- a/packages/@logossim/core/Port/Port.jsx
+++ b/packages/@logossim/core/Port/Port.jsx
@@ -44,6 +44,7 @@ class Port extends PortWidget {
         data-nodeid={model.getID()}
         port={port}
         link={port.getMainLink()}
+        title={name}
       />
     );
   }

--- a/packages/@logossim/core/Port/PortModel.js
+++ b/packages/@logossim/core/Port/PortModel.js
@@ -2,6 +2,17 @@ import { PortModel as RDPortModel } from '@projectstorm/react-diagrams';
 
 import LinkModel from '../Link/LinkModel';
 
+const validateDefaultValue = (value, type, portName) => {
+  if (value === 0) return;
+  if (value === 1) return;
+  if (value === 'x') return;
+  if (value === 'e') return;
+
+  throw new Error(
+    `[logossim] Invalid default ${type} value provided for port \`${portName}\`. Should be either 0, 1, 'x' or 'e'.`,
+  );
+};
+
 export default class PortModel extends RDPortModel {
   constructor(options = {}) {
     super({
@@ -13,6 +24,8 @@ export default class PortModel extends RDPortModel {
     this.value = null;
     this.input = null;
     this.bits = null;
+    this.defaultFloatingValue = null;
+    this.defaultErrorValue = null;
   }
 
   serialize() {
@@ -21,6 +34,8 @@ export default class PortModel extends RDPortModel {
       input: this.input,
       value: this.value,
       bits: this.bits,
+      defaultFloatingValue: this.defaultFloatingValue,
+      defaultErrorValue: this.defaultErrorValue,
     };
   }
 
@@ -29,6 +44,8 @@ export default class PortModel extends RDPortModel {
     this.value = event.data.value;
     this.input = event.data.input;
     this.bits = event.data.bits;
+    this.defaultFloatingValue = event.data.defaultFloatingValue;
+    this.defaultErrorValue = event.data.defaultErrorValue;
   }
 
   setAsInput() {
@@ -58,6 +75,30 @@ export default class PortModel extends RDPortModel {
       );
 
     this.bits = bits;
+  }
+
+  setDefaultFloatingValue(defaultFloatingValue) {
+    validateDefaultValue(
+      defaultFloatingValue,
+      'floating',
+      this.getName(),
+    );
+
+    this.defaultFloatingValue = defaultFloatingValue;
+  }
+
+  getDefaultFloatingValue() {
+    return this.defaultFloatingValue;
+  }
+
+  setDefaultErrorValue(defaultErrorValue) {
+    validateDefaultValue(defaultErrorValue, 'error', this.getName());
+
+    this.defaultErrorValue = defaultErrorValue;
+  }
+
+  getDefaultErrorValue() {
+    return this.defaultErrorValue;
   }
 
   getValue() {

--- a/packages/@logossim/core/Port/PortModel.js
+++ b/packages/@logossim/core/Port/PortModel.js
@@ -102,7 +102,13 @@ export default class PortModel extends RDPortModel {
   }
 
   getValue() {
-    return this.value;
+    if (this.value === null) return Array(this.bits).fill(0);
+
+    return this.value.map(bit => {
+      if (bit === 'x') return this.getDefaultFloatingValue();
+      if (bit === 'e') return this.getDefaultErrorValue();
+      return bit;
+    });
   }
 
   setValue(value) {

--- a/packages/@logossim/core/Simulation/const.js
+++ b/packages/@logossim/core/Simulation/const.js
@@ -1,3 +1,0 @@
-export const DEFAULT_PORT_CONFIGURATION = {
-  bits: 1,
-};

--- a/packages/@logossim/core/Simulation/const.js
+++ b/packages/@logossim/core/Simulation/const.js
@@ -1,0 +1,3 @@
+export const DEFAULT_PORT_CONFIGURATION = {
+  bits: 1,
+};

--- a/packages/@logossim/core/Simulation/deserialize.js
+++ b/packages/@logossim/core/Simulation/deserialize.js
@@ -6,7 +6,7 @@
 
 /* ---------------------------------------------------------------- */
 import findMeshes from './mesh';
-import { convertNumberValueToArray, isValueEqual } from './utils';
+import { isValueEqual } from './utils';
 
 /**
  * This class represents a generic component. It receives deserialized
@@ -24,6 +24,12 @@ export class GenericComponent {
     });
 
     this.initialize(properties.configurations);
+  }
+
+  getPort(name) {
+    return [...this.ports.input, ...this.ports.output].find(
+      port => port.name === name,
+    );
   }
 
   getInputPort(name) {
@@ -44,10 +50,7 @@ export class GenericComponent {
       if (values[port.name] !== undefined) {
         current = values[port.name];
         if (typeof current === 'number') {
-          current = convertNumberValueToArray(
-            values[port.name],
-            port.bits,
-          );
+          current = values[port.name].asArray(port.bits);
         } else if (current === 'x' || current === 'e') {
           current = Array(port.bits).fill(current);
           errorOrFloating = true;
@@ -57,10 +60,14 @@ export class GenericComponent {
       }
 
       current = current.map(bit => {
-        if (bit === 'x') return port.defaultFloatingValue;
-        if (bit === 'e') return port.defaultErrorValue;
+        if (bit === 'x') return port.defaultFloatingValue ?? 'x';
+        if (bit === 'e') return port.defaultErrorValue ?? 'e';
         return bit;
       });
+
+      if (previous.some(bit => bit === 'x' || bit === 'e')) {
+        errorOrFloating = true;
+      }
 
       const risingEdge = !errorOrFloating && previous < current;
       const fallingEdge = !errorOrFloating && previous > current;
@@ -83,6 +90,17 @@ export class GenericComponent {
 
   setOutputValues(values) {
     this.setValues(values, 'output');
+  }
+
+  setWireValues(values) {
+    this.ports.output = this.ports.output.map(port => {
+      if (!values[port.name]) return port;
+
+      return {
+        ...port,
+        linkValue: values[port.name],
+      };
+    });
   }
 
   hasOutputChanged(values) {
@@ -266,6 +284,20 @@ const deserializeModels = models =>
       {},
     );
 
+const deserializePort = port => ({
+  ...port,
+  value: new Array(port.bits || 1).fill(port.defaultFloatingValue),
+  linkValue: new Array(port.bits || 1).fill(
+    port.defaultFloatingValue,
+  ),
+  getValue() {
+    return this.value;
+  },
+  getWireValue() {
+    return this.linkValue;
+  },
+});
+
 /**
  * Deserialize a given diagram (serialized), generating
  * `GenericComponent` instances with its given methods and properties.
@@ -284,20 +316,10 @@ const deserialize = serialized => {
             ports: {
               input: component.ports
                 .filter(port => port.input)
-                .map(port => ({
-                  ...port,
-                  value: new Array(port.bits || 1).fill(
-                    port.defaultFloatingValue,
-                  ),
-                })),
+                .map(deserializePort),
               output: component.ports
                 .filter(port => !port.input)
-                .map(port => ({
-                  ...port,
-                  value: new Array(port.bits || 1).fill(
-                    port.defaultFloatingValue,
-                  ),
-                })),
+                .map(deserializePort),
             },
           },
           models[component.type],

--- a/packages/@logossim/core/Simulation/serialize.js
+++ b/packages/@logossim/core/Simulation/serialize.js
@@ -56,6 +56,8 @@ const serializePorts = ports =>
     name: port.getName(),
     input: port.isInput(),
     bits: port.getBits(),
+    defaultFloatingValue: port.getDefaultFloatingValue(),
+    defaultErrorValue: port.getDefaultErrorValue(),
   }));
 
 /**

--- a/packages/@logossim/core/Simulation/utils.js
+++ b/packages/@logossim/core/Simulation/utils.js
@@ -8,28 +8,6 @@ export const MAX_VALUE = {
   16: 0b1111_1111_1111_1111,
 };
 
-export const convertNumberValueToArray = (value, dataBits) => {
-  if (Array.isArray(value)) return value;
-
-  const result = [...value.toString(2)].map(Number);
-
-  return Array(dataBits)
-    .fill(0)
-    .concat(result)
-    .slice(result.length);
-};
-
-export const convertArrayValueToNumber = value => {
-  if (!Array.isArray(value)) return value;
-
-  if (value.includes('e')) return 'e';
-
-  return value
-    .slice()
-    .reverse()
-    .reduce((acc, curr, index) => acc + curr * 2 ** index, 0);
-};
-
 export const adjustValueToBits = (value, dataBits = 1) => {
   if (typeof value !== 'number') return value;
 
@@ -93,6 +71,14 @@ export const getAffectedMeshes = emitted =>
   );
 
 /**
+ * Finds all components that are connected on a given mesh's Input.
+ */
+export const getMeshInputComponents = mesh =>
+  [
+    ...new Set(mesh.inputs.map(meshInput => meshInput.componentId)),
+  ].map(componentId => getComponent(componentId));
+
+/**
  * Finds all components that are connected on a given mesh's output.
  */
 export const getMeshOutputComponents = mesh =>
@@ -139,7 +125,7 @@ export const getMeshInputValue = mesh => {
 };
 
 /**
- * Initialize all links and ports with the value 0.
+ * Initialize all links and ports with the floating value.
  */
 export const initializeDiffAndValues = () => {
   self.circuit.components.forEach(component => {
@@ -205,7 +191,7 @@ export const appendComponentDiff = (component, output) => {
   }
   self.diff.components[component.id] = {
     ...self.diff.components[component.id],
-    output,
+    output: output || self.diff.components[component.id].output,
     properties: component.getProperties(),
   };
 };

--- a/packages/@logossim/core/common/prototype.js
+++ b/packages/@logossim/core/common/prototype.js
@@ -17,6 +17,10 @@ Array.prototype.asNumber = function arrayAsNumber() {
     .reduce((acc, curr, index) => acc + curr * 2 ** index, 0);
 };
 
+Array.prototype.transpose = function transpose() {
+  return this[0].map((x1, i) => this.map(x2 => x2[i]));
+};
+
 Number.prototype.asNumber = function numberAsNumber() {
   return Number(this);
 };
@@ -26,12 +30,26 @@ Number.prototype.asArray = function numberAsArray(dataBits) {
     throw new Error(
       '[logossim] To transform a number to array, you need to pass as argument the length of the array',
     );
+
   const result = [...this.toString(2)].map(Number);
 
   return Array(dataBits)
     .fill(0)
     .concat(result)
     .slice(result.length);
+};
+
+String.prototype.asArray = function stringAsArray(dataBits) {
+  if (!dataBits)
+    throw new Error(
+      '[logossim] To transform a number to array, you need to pass as argument the length of the array',
+    );
+
+  return [...this.padStart(dataBits, 0)].map(char => {
+    if (char === '0') return 0;
+    if (char === '1') return 1;
+    return char;
+  });
 };
 
 String.prototype.parseBinary = function parseBinary(

--- a/packages/@logossim/core/common/prototype.js
+++ b/packages/@logossim/core/common/prototype.js
@@ -1,0 +1,66 @@
+/* eslint-disable no-extend-native */
+Array.prototype.asArray = function arrayAsArray() {
+  return this;
+};
+
+Array.prototype.asNumber = function arrayAsNumber() {
+  if (this.some(bit => bit === 'e')) return 'e';
+  if (this.some(bit => bit === 'x')) return 'x';
+
+  if (this.some(bit => bit !== 0 && bit !== 1))
+    throw new Error(
+      '[logossim] Array cannot be converted to number because it contains invalid values',
+    );
+
+  return this.slice()
+    .reverse()
+    .reduce((acc, curr, index) => acc + curr * 2 ** index, 0);
+};
+
+Number.prototype.asNumber = function numberAsNumber() {
+  return Number(this);
+};
+
+Number.prototype.asArray = function numberAsArray(dataBits) {
+  if (!dataBits)
+    throw new Error(
+      '[logossim] To transform a number to array, you need to pass as argument the length of the array',
+    );
+  const result = [...this.toString(2)].map(Number);
+
+  return Array(dataBits)
+    .fill(0)
+    .concat(result)
+    .slice(result.length);
+};
+
+String.prototype.parseBinary = function parseBinary(
+  dataBits,
+  arrayLength,
+  fillWith = 0,
+) {
+  if (!dataBits)
+    throw new Error(
+      '[logossim] To parse a binary, you need to pass the value length in bits as first argument.',
+    );
+
+  if (!arrayLength)
+    throw new Error(
+      '[logossim] To parse a binary, you need to pass the result array length as second argument.',
+    );
+
+  const sanitize = /[^01]/g;
+  const chunk = new RegExp(`.{1,${dataBits}}`, 'g');
+
+  const content = (
+    this.replace(sanitize, '').match(chunk) || []
+  ).map(value => parseInt(value, 2));
+
+  return Array(arrayLength)
+    .fill(fillWith)
+    .map((original, i) => {
+      const value = content[i];
+      if (!value) return original;
+      return value;
+    });
+};

--- a/packages/@logossim/page/src/App.jsx
+++ b/packages/@logossim/page/src/App.jsx
@@ -176,6 +176,7 @@ export default class App extends Component {
       return;
     }
 
+    // eslint-disable-next-line no-alert
     const reload = window.confirm('Reload last unsaved circuit?');
     if (reload) {
       this.loadFile(lastSaved);

--- a/packages/@logossim/page/src/index.js
+++ b/packages/@logossim/page/src/index.js
@@ -4,6 +4,8 @@ import ReactDOM from 'react-dom';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 
+import '@logossim/core/common/prototype';
+
 ReactDOM.render(<App />, document.getElementById('root'));
 
 // If you want your app to work offline and load faster, you can change

--- a/packages/@logossim/page/src/setupTests.js
+++ b/packages/@logossim/page/src/setupTests.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-classes-per-file */
+import { DEFAULT_PORT_CONFIGURATION } from '@logossim/core/Simulation/const';
 import '@testing-library/jest-dom/extend-expect';
 
 // Mocks `worker-loader`
@@ -54,6 +55,9 @@ global.engine = {
   getModel: () => ({ isLocked: () => false }),
 };
 
-global.addPort = function addPort(portName, dataBits = 1) {
-  this.ports[portName] = { bits: dataBits };
+global.addPort = function addPort(
+  portName,
+  { bits = 1 } = DEFAULT_PORT_CONFIGURATION,
+) {
+  this.ports[portName] = { bits };
 };

--- a/packages/@logossim/page/src/setupTests.js
+++ b/packages/@logossim/page/src/setupTests.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-classes-per-file */
 import '@testing-library/jest-dom/extend-expect';
+import '@logossim/core/common/prototype';
 
 // Mocks `worker-loader`
 jest.mock('../../core/Simulation/simulation.worker.js', () => ({

--- a/packages/@logossim/page/src/setupTests.js
+++ b/packages/@logossim/page/src/setupTests.js
@@ -43,18 +43,6 @@ document.createRange = () => ({
   },
 });
 
-// react-diagrams engine stub
-global.engine = {
-  registerListener: () => {},
-  getCanvas: () => {},
-  getPortCoords: () => ({
-    getWidth: () => {},
-    getHeight: () => {},
-    getTopLeft: () => {},
-  }),
-  getModel: () => ({ isLocked: () => false }),
-};
-
 global.addPort = function addPort(
   portName,
   { bits = 1 } = DEFAULT_PORT_CONFIGURATION,

--- a/packages/@logossim/page/src/setupTests.js
+++ b/packages/@logossim/page/src/setupTests.js
@@ -1,5 +1,4 @@
 /* eslint-disable max-classes-per-file */
-import { DEFAULT_PORT_CONFIGURATION } from '@logossim/core/Simulation/const';
 import '@testing-library/jest-dom/extend-expect';
 
 // Mocks `worker-loader`
@@ -43,9 +42,6 @@ document.createRange = () => ({
   },
 });
 
-global.addPort = function addPort(
-  portName,
-  { bits = 1 } = DEFAULT_PORT_CONFIGURATION,
-) {
-  this.ports[portName] = { bits };
+global.addPort = function addPort(portName, { bits } = {}) {
+  this.ports[portName] = { bits: bits || 1 };
 };

--- a/packages/@logossim/page/src/ui-components/ComponentSelect/ComponentConfigurationInput.jsx
+++ b/packages/@logossim/page/src/ui-components/ComponentSelect/ComponentConfigurationInput.jsx
@@ -35,10 +35,16 @@ const Container = styled.div`
 
     padding: 10px 0 5px 16px;
   }
+
+  input[type='file'] {
+    font-size: 1em;
+    margin-top: 2px;
+  }
 `;
 
 const Input = ({
   // Formik
+  form,
   field,
   // General
   name,
@@ -53,12 +59,37 @@ const Input = ({
   min,
   max,
 }) => {
+  const handleBinaryLoad = event => {
+    const {
+      target: { files },
+    } = event;
+
+    if (files.length !== 1) return;
+
+    const handleError = () =>
+      this.showSnackbar(
+        `Error loading binary file:\n${files[0].name}`,
+      );
+
+    const fr = new FileReader();
+    fr.onerror = handleError;
+    fr.onload = e => {
+      try {
+        const file = e.target.result;
+        form.setFieldValue(field.name, file);
+      } catch (exception) {
+        handleError();
+      }
+    };
+    fr.readAsText(files.item(0));
+  };
+
   switch (type) {
     case 'select':
       return (
         <>
           <label htmlFor={name}>{label}</label>
-          <select id={field.name} ref={innerRef} {...field}>
+          <select id={name} ref={innerRef} {...field}>
             {options.map(option => (
               <option value={option.value} key={option.value}>
                 {option.label}
@@ -72,7 +103,7 @@ const Input = ({
         <>
           <label htmlFor={name}>{label}</label>
           <input
-            id={field.name}
+            id={name}
             ref={innerRef}
             {...field}
             step={step}
@@ -86,11 +117,18 @@ const Input = ({
       return (
         <>
           <label htmlFor={name}>{label}</label>
+          <input id={name} ref={innerRef} {...field} type="text" />
+        </>
+      );
+    case 'binary':
+      return (
+        <>
+          <label htmlFor={name}>{label}</label>
           <input
-            id={field.name}
-            ref={innerRef}
-            {...field}
-            type="text"
+            id={name}
+            accept=".lgbin"
+            type="file"
+            onChange={handleBinaryLoad}
           />
         </>
       );

--- a/packages/@logossim/page/src/ui-components/ComponentSelect/DraggableComponent.jsx
+++ b/packages/@logossim/page/src/ui-components/ComponentSelect/DraggableComponent.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Tooltip from 'react-tooltip';
 
+import ComponentContext from '@logossim/core/ComponentContext';
 import DiagramContext from '@logossim/core/Diagram/DiagramContext';
 
 import styled from 'styled-components';
@@ -37,41 +38,47 @@ const DraggableComponent = ({
   handleClose,
   error,
   disabled,
-}) => (
-  <div
-    draggable={!error && !disabled}
-    onDragStart={event => {
-      event.dataTransfer.setDragImage(
-        event.currentTarget.children[0],
-        0,
-        0,
-      );
+}) => {
+  const model = new Model(configurations, type);
 
-      event.dataTransfer.setData(
-        'component',
-        JSON.stringify({
-          type,
-          configurations,
-        }),
-      );
+  return (
+    <div
+      draggable={!error && !disabled}
+      onDragStart={event => {
+        event.dataTransfer.setDragImage(
+          event.currentTarget.children[0],
+          0,
+          0,
+        );
 
-      requestAnimationFrame(() => {
-        Tooltip.hide();
-        handleClose();
-      });
-    }}
-    data-for="tooltip"
-    data-tip={getTooltip(error, disabled)}
-    data-place="bottom"
-  >
-    {error ? (
-      <ErrorWidget />
-    ) : (
-      <DiagramContext.Provider value={diagramEngineStub}>
-        <Widget model={new Model(configurations, type)} />
-      </DiagramContext.Provider>
-    )}
-  </div>
-);
+        event.dataTransfer.setData(
+          'component',
+          JSON.stringify({
+            type,
+            configurations,
+          }),
+        );
+
+        requestAnimationFrame(() => {
+          Tooltip.hide();
+          handleClose();
+        });
+      }}
+      data-for="tooltip"
+      data-tip={getTooltip(error, disabled)}
+      data-place="bottom"
+    >
+      {error ? (
+        <ErrorWidget />
+      ) : (
+        <DiagramContext.Provider value={diagramEngineStub}>
+          <ComponentContext.Provider value={model}>
+            <Widget model={model} />
+          </ComponentContext.Provider>
+        </DiagramContext.Provider>
+      )}
+    </div>
+  );
+};
 
 export default DraggableComponent;

--- a/packages/@logossim/page/src/ui-components/ComponentSelect/DraggableComponent.jsx
+++ b/packages/@logossim/page/src/ui-components/ComponentSelect/DraggableComponent.jsx
@@ -1,17 +1,21 @@
 import React from 'react';
 import Tooltip from 'react-tooltip';
 
+import DiagramContext from '@logossim/core/Diagram/DiagramContext';
+
 import styled from 'styled-components';
 
-const engineStub = {
-  registerListener: () => {},
-  getCanvas: () => {},
-  getPortCoords: () => ({
-    getWidth: () => {},
-    getHeight: () => {},
-    getTopLeft: () => {},
+const diagramEngineStub = {
+  getEngine: () => ({
+    registerListener: () => {},
+    getCanvas: () => {},
+    getPortCoords: () => ({
+      getWidth: () => {},
+      getHeight: () => {},
+      getTopLeft: () => {},
+    }),
+    getModel: () => ({ isLocked: () => false }),
   }),
-  getModel: () => ({ isLocked: () => false }),
 };
 
 const getTooltip = (error, disabled) => {
@@ -63,10 +67,9 @@ const DraggableComponent = ({
     {error ? (
       <ErrorWidget />
     ) : (
-      <Widget
-        engine={engineStub}
-        model={new Model(configurations, type)}
-      />
+      <DiagramContext.Provider value={diagramEngineStub}>
+        <Widget model={new Model(configurations, type)} />
+      </DiagramContext.Provider>
     )}
   </div>
 );

--- a/packages/@logossim/page/src/ui-components/Snackbar/Snackbar.jsx
+++ b/packages/@logossim/page/src/ui-components/Snackbar/Snackbar.jsx
@@ -84,8 +84,9 @@ const Snackbar = ({ open, handleClose, message, type, timeout }) => {
       onClick={handleClose}
     >
       <Message>
-        {message.split(`\n`).map(string => (
-          <div key={string}>{string}</div>
+        {message.split(`\n`).map((string, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <div key={index}>{string}</div>
         ))}
       </Message>
 


### PR DESCRIPTION
This PR contains **a lot** of changes:
- **implements "values as arrays":** values now are received as numbers on `step` and as arrays on `stepError` and `stepFloating` (new). Also adds auxiliary functions to `Array`, `Number` and `String` prototypes to facilitate the conversion between these values.
- **implements the floating value type:** this is meant to be used as the "neither zero or one" value. This has been set as the default value for simulation initialization (previously was the value 0).
- **adds new port configurations:** now, the second argument for the `addInputPort` and `addOutputPort` is an object (instead of the number of bits). This object takes the keys `bits`, `error` and `floating`, being `bits` the bit width of the port. The new configurations `error` and `floating`, allows the developer to define a replacement value whenever the component takes as input an error or an floating value.
- **simulation refactors and fixes:** a bunch of fixes and refactors on the simulation engine.
- **improves `Port` API:** removed the necessity to pass in the props `model`, `port` and `engine` to the `Port` React component. Now, the only prop needed is `name`.
- **adds `getWireValue` to port model:** this allows to access the value of the wire connected to a port. Useful for I/O.
- **adds port name tooltip:** the port name will be shown when the user hovers a port.
- **refactor tests:** refactored every test file to add a `describe` block for better organization.
- **adds support for binaries**: adds the support for the user to upload a "binary" file. This file has the `.lgbin` extension, and it's actually a text file (for simplicity's sake). Also adds the `parseBinary` function to `String` prototype, which will ignore anything that's not a `'0'` or a `'1'` and transform the contents of this binary file into a array of values to be used by the component.

---

Also adds 3 new components:
- RAM
![image](https://user-images.githubusercontent.com/25781956/113791474-1c058600-971a-11eb-93cc-708acc11af6b.png)
- ROM
![image](https://user-images.githubusercontent.com/25781956/113791508-30498300-971a-11eb-8398-634d377bd1fe.png)
- Counter
![image](https://user-images.githubusercontent.com/25781956/113791525-39d2eb00-971a-11eb-9d62-7738befd2e95.png)
