### PR TITLE
Fixes bundling process

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "styled-components": "^5.0.0"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-numeric-separator": "7.8.3",
+    "babel-loader": "8.1.0",
     "eslint": "^6.5.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.1.0",

--- a/packages/@logossim/components/Joiner/JoinerModel.js
+++ b/packages/@logossim/components/Joiner/JoinerModel.js
@@ -12,21 +12,17 @@ export default class JoinerModel extends BaseModel {
 
   step(input) {
     return {
-      out: [...new Array(this.bits)]
-        .map((_, index) => input[`in${index}`])
-        .reduce((acc, curr, index) => acc + curr * 2 ** index, 0),
+      out: Object.values(input)
+        .map(value => value.asArray(1)[0])
+        .map((_, index, arr) => arr[arr.length - index - 1]),
     };
   }
 
   stepFloating(input) {
-    return {
-      out: [...new Array(this.bits)]
-        .map((_, index) => input[`in${this.bits - index - 1}`])
-        .flat(),
-    };
+    return this.step(input);
   }
 
   stepError(input) {
-    return this.stepFloating(input);
+    return this.step(input);
   }
 }

--- a/packages/@logossim/components/Joiner/__tests__/JoinerModel.test.js
+++ b/packages/@logossim/components/Joiner/__tests__/JoinerModel.test.js
@@ -27,8 +27,10 @@ describe('JoinerModel', () => {
   });
 
   it('should correctly join the input value', () => {
+    const DATA_BITS = 16;
+
     const model = new JoinerModel({
-      DATA_BITS: 16,
+      DATA_BITS,
     });
 
     expect(
@@ -51,7 +53,7 @@ describe('JoinerModel', () => {
         in15: 1,
       }),
     ).toEqual({
-      out: 0b1010_0101_1111_0000,
+      out: (0b1010_0101_1111_0000).asArray(DATA_BITS),
     });
   });
 

--- a/packages/@logossim/components/Splitter/SplitterModel.js
+++ b/packages/@logossim/components/Splitter/SplitterModel.js
@@ -10,32 +10,22 @@ export default class SplitterModel extends BaseModel {
     }
   }
 
-  getBitAt(input, index) {
-    const mask = 0b1 << index;
-    const result = input & mask;
-
-    return result > 0 ? 1 : 0;
-  }
-
   step(input) {
     return Object.fromEntries(
-      [...new Array(this.bits)].map((_, index) => [
-        `out${index}`,
-        this.getBitAt(input.in, index),
-      ]),
+      input.in
+        .asArray(this.bits)
+        .map((bit, index, { length }) => [
+          `out${length - index - 1}`,
+          bit,
+        ]),
     );
   }
 
   stepFloating(input) {
-    return Object.fromEntries(
-      [...new Array(this.bits)].map((_, index) => [
-        `out${this.bits - index - 1}`,
-        [input.in[index]],
-      ]),
-    );
+    return this.step(input);
   }
 
   stepError(input) {
-    return this.stepFloating(input);
+    return this.step(input);
   }
 }

--- a/packages/@logossim/components/Splitter/__tests__/SplitterModel.test.js
+++ b/packages/@logossim/components/Splitter/__tests__/SplitterModel.test.js
@@ -65,8 +65,8 @@ describe('SplitterModel', () => {
         in: [0, 'x'],
       }),
     ).toEqual({
-      out0: ['x'],
-      out1: [0],
+      out0: 'x',
+      out1: 0,
     });
   });
 
@@ -80,8 +80,8 @@ describe('SplitterModel', () => {
         in: [0, 'e'],
       }),
     ).toEqual({
-      out0: ['e'],
-      out1: [0],
+      out0: 'e',
+      out1: 0,
     });
   });
 });

--- a/packages/@logossim/core/Simulation/deserialize.js
+++ b/packages/@logossim/core/Simulation/deserialize.js
@@ -255,19 +255,13 @@ export class GenericComponent {
  */
 const deserializeMethod = model =>
   Object.fromEntries(
-    Object.entries(model.methods).map(([key, stringFn]) => [
-      key,
-      // eslint-disable-next-line no-new-func
-      new Function(
-        `return ${
-          /**
-           * We need to add the `function` token when on development
-           * environment.
-           */
-          process.env.NODE_ENV === 'development' ? 'function ' : ''
-        }${stringFn}`,
-      )(),
-    ]),
+    Object.entries(model.methods).map(([key, stringFn]) => {
+      return [
+        key,
+        // eslint-disable-next-line no-new-func
+        new Function(`return function ${stringFn}`)(),
+      ];
+    }),
   );
 
 const deserializeModels = models =>


### PR DESCRIPTION
The bundling process was breaking some components (Demux, Splitter and Joiner) on production. That was happening because `babel-loader` was transforming the rest operator (which those components used on their implementation), but that transformation didn't work in the simulation worker context.